### PR TITLE
footer: Remove copyright year

### DIFF
--- a/src/components/shared/footer/footer.jsx
+++ b/src/components/shared/footer/footer.jsx
@@ -37,7 +37,7 @@ const Footer = () => (
         </div>
       </div>
       <div className="mt-10 space-y-3 text-sm lg:mt-16 with-link-primary-light text-gray-1">
-        <p>© 2021 Cilium Authors. All rights reserved.</p>
+        <p>Copyright The Cilium Authors. All rights reserved.</p>
         <p>
           The Linux Foundation has registered trademarks and uses trademarks. For a list of
           trademarks of The Linux Foundation, please see our{' '}


### PR DESCRIPTION
The current copyright year appearing in the footer (2021) is outdated. We could replace it, but as Liz observed, [the CNCF recommends dropping it](https://github.com/cncf/foundation/blob/main/copyright-notices.md#copyright-notices). Let's update the footer to remove the copyright year. I think that the `All rights reserved.` may be covered by the Copyright mention and could maybe be removed as well, but in doubt, I didn't touch that part.
