### PR TITLE
fix: move tweet cards

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -178,8 +178,8 @@ const IndexPage = () => (
     <UserCommunity {...userCommunity2} />
     <FeaturedTalks />
     <Learn />
-    <TwitterCards />
     <Community withBanner />
+    <TwitterCards />
   </MainLayout>
 );
 


### PR DESCRIPTION
This pull request moves the tweet cards after the Community section on the Home page.
 
**Screenshots**
<img width="1413" alt="image" src="https://user-images.githubusercontent.com/48465000/157207757-81236087-4835-4127-9a85-e380d805077e.png">
