### PR TITLE
chore: add redirect for install-aws-marketplace page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -22,3 +22,4 @@
 /hubble https://github.com/cilium/hubble 301
 /blog/2020/11/10/ebpf-future-of-network/ https://cilium.io/blog/2020/11/10/ebpf-future-of-networking/ 301
 /swag https://shop.spreadshirt.net/cilium 301
+/install-aws-marketplace https://isovalent.com/install-aws-marketplace 301


### PR DESCRIPTION
This pull request brings the redirect for `/install-aws-marketplace` to https://isovalent.com/install-aws-marketplace.