### PR TITLE
feat: add CSP for frame-ancestors

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -135,6 +135,7 @@ const plugins = [
     options: {
       headers: {
         '/fonts/*': ['Cache-Control: public, max-age=31536000, immutable'],
+        '/*': ['Content-Security-Policy: frame-ancestors instruqt.com play.instruqt.com'],
       },
     },
   },


### PR DESCRIPTION
This PR brings Content Security Policy headers to add instruqt.com and play.instruqt.com to allowed frame-ancestors
