### PR TITLE
fix: fix 1.11-release blog post cover link

### DIFF
--- a/src/posts/2021-12-09-release-1.11/index.md
+++ b/src/posts/2021-12-09-release-1.11/index.md
@@ -1,7 +1,7 @@
 ---
 date: '2021-12-09T17:00:00.000Z'
 title: 'What’s new in Cilium 1.11? Service Mesh Beta, Topology Aware Routing, OpenTelemetry'
-ogImageUrl: 'https://isovalent.com/assets/blog/2021-12-release-111/ogimage.png'
+ogImageUrl: 'https://isovalent.com/static/bebd46e81195ea0ca40ce2454966e212/d5ccc/ogimage.jpg'
 ogSummary: 'Coverage of many new features in the Cilium 1.11 release.'
 categories:
   - Release


### PR DESCRIPTION
This PR bring an ogImage link fix for the 1.11 release external blog post.