### PR TITLE
feat: add labs link to training section

### DIFF
--- a/src/components/pages/enterprise/training/training.jsx
+++ b/src/components/pages/enterprise/training/training.jsx
@@ -29,9 +29,10 @@ const items = [
     logoName: 'isovalent',
     title: 'Getting started with Cilium',
     description:
-      'Quickly get started with Cilium. Read the documentation or use our interactive tutorial in a live environment.',
-    buttonText: 'Coming soon',
-    buttonDisabled: true,
+      'Quickly get started with Cilium in our interactive tutorials with a live environment.',
+    buttonText: 'Explore Tutorials',
+    buttonLink: 'https://isovalent.com/labs/',
+    buttonTarget: '_blank',
   },
 ];
 


### PR DESCRIPTION
This PR brings an update for the Training section on the [Enterprise](https://deploy-preview-97--cilium.netlify.app/enterprise) page