### PR TITLE
Add netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  publish = "public"
+  command = "gatsby build"
+
+[[redirects]]
+  from = "https://blog.cilium.io/*"
+  to = "https://cilium.io/blog/:splat"
+  status = 200
+  force = true


### PR DESCRIPTION
- The build section configuration comes from "Build settings" in the Netlify UI.
- Serve /blog from blog.cilium.io.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>