### PR TITLE
Move blog.cilium.io redirect rule to static/_redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,3 @@
 [build]
   publish = "public"
   command = "gatsby build"
-
-[[redirects]]
-  from = "https://blog.cilium.io/*"
-  to = "https://cilium.io/blog/:splat"
-  status = 200
-  force = true

--- a/static/_redirects
+++ b/static/_redirects
@@ -24,4 +24,5 @@
 /istio /blog/2018/08/07/istio-10-cilium 301
 /blog/2020/11/10/ebpf-future-of-network /blog/2020/11/10/ebpf-future-of-networking 301
 
+https://blog.cilium.io/* /blog/:splat 200!
 /* https://cilium.netlify.app/:splat 200


### PR DESCRIPTION
Adding it to netlify.toml didn't work.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>