### PR TITLE
Redirect blog.cilium.io/* to cilium.netlify.app/blog/:splat

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -24,5 +24,5 @@
 /istio /blog/2018/08/07/istio-10-cilium 301
 /blog/2020/11/10/ebpf-future-of-network /blog/2020/11/10/ebpf-future-of-networking 301
 
-https://blog.cilium.io/* /blog/:splat 200!
+https://blog.cilium.io/* https://cilium.netlify.app/blog/:splat 200!
 /* https://cilium.netlify.app/:splat 200


### PR DESCRIPTION
Redirecting to relative URL doesn't work, I'm guessing it's because blog.cilium.io/blog/ gets redirected to blog.cilium.io/blog/blog/.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>