### PR TITLE
fix: create github stars nodes inside sourceNodes

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -201,43 +201,40 @@ exports.sourceNodes = async ({ actions: { createNode }, createContentDigest }) =
   });
 };
 
-exports.createResolvers = ({ createResolvers, cache }) => {
-  createResolvers({
-    Query: {
-      githubStars: {
-        type: 'String',
-        resolve: async () => {
-          try {
-            let stars;
-            // Set expiration time as 24 hours in milliseconds
-            const expirationTime = 24 * 60 * 60 * 1000;
-            const cacheKey = `stars-cilium`;
-            const cacheStarsData = await cache.get(cacheKey);
-            // Use cache if it is not expired
-            if (cacheStarsData && cacheStarsData.created > Date.now() - expirationTime) {
-              stars = cacheStarsData.stars;
-            } else {
-              // Use setTimeout to avoid hitting GitHub API rate limit with a random delay with interval from 500ms to 1500ms
-              await new Promise((resolve) => setTimeout(resolve, Math.random() * 3000 + 500));
-              const response = await fetch('https://api.github.com/repos/cilium/cilium');
-              const { stargazers_count } = await response.json();
-              if (!stargazers_count) {
-                throw new Error('Failed to fetch GitHub stars');
-              }
-              stars = new Intl.NumberFormat('en-US').format(stargazers_count);
-              await cache.set(cacheKey, {
-                stars,
-                created: Date.now(),
-              });
-            }
+exports.sourceNodes = async ({ actions: { createNode }, createContentDigest, cache }) => {
+  let stars;
+  // Set expiration time as 24 hours in milliseconds
+  const expirationTime = 24 * 60 * 60 * 1000;
+  const cacheKey = `stars-cilium`;
+  const cacheStarsData = await cache.get(cacheKey);
+  // Use cache if it is not expired
+  if (cacheStarsData && cacheStarsData.created > Date.now() - expirationTime) {
+    stars = cacheStarsData.stars;
+  } else {
+    // Use setTimeout to avoid hitting GitHub API rate limit with a random delay with interval from 500ms to 1500ms
+    await new Promise((resolve) => {
+      setTimeout(resolve, Math.random() * 3000 + 500);
+    });
+    const response = await fetch(`https://api.github.com/repos/cilium/cilium`);
+    const { stargazers_count } = await response.json();
+    if (!stargazers_count) {
+      throw new Error('Failed to fetch GitHub stars of Cilium');
+    }
+    stars = new Intl.NumberFormat('en-US').format(stargazers_count);
+    await cache.set(cacheKey, {
+      stars,
+      created: Date.now(),
+    });
+  }
 
-            return stars;
-          } catch (error) {
-            console.log(error);
-            throw new Error('Failed to fetch GitHub stars');
-          }
-        },
-      },
+  createNode({
+    id: `github-stars-cilium`,
+    parent: null,
+    githubStars: stars,
+    children: [],
+    internal: {
+      type: `GithubStars`,
+      contentDigest: createContentDigest(stars),
     },
   });
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -249,7 +249,9 @@ async function getGithubStars({ actions: { createNode }, createContentDigest, ca
       if (typeof stargazers_count !== 'number') {
         throw new Error('Failed to fetch GitHub stars');
       }
-      stars = new Intl.NumberFormat('en-US').format(stargazers_count);
+
+      // covert stars to string
+      stars = stargazers_count.toString();
 
       await cache.set(cacheKey, {
         stars,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -243,14 +243,10 @@ async function getGithubStars({ actions: { createNode }, createContentDigest, ca
     if (cacheStarsData && cacheStarsData.created > Date.now() - expirationTime) {
       stars = cacheStarsData.stars;
     } else {
-      // Use setTimeout to avoid hitting GitHub API rate limit with a random delay with interval from 500ms to 1500ms
-      await new Promise((resolve) => {
-        setTimeout(resolve, Math.random() * 3000 + 500);
-      });
-
       const response = await fetch(`https://api.github.com/repos/cilium/cilium`);
       const { stargazers_count } = await response.json();
-      if (!stargazers_count) {
+
+      if (typeof stargazers_count !== 'number') {
         throw new Error('Failed to fetch GitHub stars');
       }
       stars = new Intl.NumberFormat('en-US').format(stargazers_count);

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -184,47 +184,85 @@ exports.onCreateNode = ({ node, actions }) => {
   }
 };
 
-exports.sourceNodes = async ({ actions: { createNode }, createContentDigest }) => {
-  const hubspotEmails = await fetch(
-    `https://api.hubapi.com/marketing-emails/v1/emails?hapikey=${process.env.HUBSPOT_API_KEY}&limit=150&name__icontains=eCHO+news&orderBy=-publish_date`
-  );
-  const hubspotEmailsData = await hubspotEmails.json();
+async function getHubspotEmails({ actions: { createNode }, createContentDigest }) {
+  const getObjects = async () => {
+    if (process.env.NODE_ENV === 'production' && process.env.HUBSPOT_ACCESS_TOKEN) {
+      let hubspotEmailsData;
+      try {
+        const hubspotEmails = await fetch(
+          `https://api.hubapi.com/marketing-emails/v1/emails?limit=150&name__icontains=eCHO+news&orderBy=-publish_date`,
+          {
+            method: 'GET',
+            headers: {
+              Authorization: `Bearer ${process.env.HUBSPOT_ACCESS_TOKEN}`,
+              'Content-Type': 'application/json',
+            },
+          }
+        );
+        hubspotEmailsData = await hubspotEmails.json();
+      } catch (error) {
+        console.log(error);
+        return [];
+      }
+
+      return hubspotEmailsData.objects
+        .filter(({ isPublished }) => isPublished !== false)
+        .map(({ name, publishDate, isPublished, publishedUrl }) => ({
+          name,
+          publishDate,
+          isPublished,
+          publishedUrl,
+        }));
+    }
+
+    return [];
+  };
+
+  const objects = await getObjects();
+
   createNode({
-    objects: hubspotEmailsData.objects,
+    objects,
     id: `hubspot-email-data`,
     parent: null,
     children: [],
     internal: {
       type: `HubspotEmails`,
-      contentDigest: createContentDigest(hubspotEmailsData),
+      contentDigest: createContentDigest(objects),
     },
   });
-};
+}
 
-exports.sourceNodes = async ({ actions: { createNode }, createContentDigest, cache }) => {
+async function getGithubStars({ actions: { createNode }, createContentDigest, cache }) {
   let stars;
-  // Set expiration time as 24 hours in milliseconds
-  const expirationTime = 24 * 60 * 60 * 1000;
-  const cacheKey = `stars-cilium`;
-  const cacheStarsData = await cache.get(cacheKey);
-  // Use cache if it is not expired
-  if (cacheStarsData && cacheStarsData.created > Date.now() - expirationTime) {
-    stars = cacheStarsData.stars;
-  } else {
-    // Use setTimeout to avoid hitting GitHub API rate limit with a random delay with interval from 500ms to 1500ms
-    await new Promise((resolve) => {
-      setTimeout(resolve, Math.random() * 3000 + 500);
-    });
-    const response = await fetch(`https://api.github.com/repos/cilium/cilium`);
-    const { stargazers_count } = await response.json();
-    if (!stargazers_count) {
-      throw new Error('Failed to fetch GitHub stars of Cilium');
+  try {
+    // Set expiration time as 24 hours in milliseconds
+    const expirationTime = 24 * 60 * 60 * 1000;
+    const cacheKey = `stars-cilium`;
+    const cacheStarsData = await cache.get(cacheKey);
+    // Use cache if it is not expired
+    if (cacheStarsData && cacheStarsData.created > Date.now() - expirationTime) {
+      stars = cacheStarsData.stars;
+    } else {
+      // Use setTimeout to avoid hitting GitHub API rate limit with a random delay with interval from 500ms to 1500ms
+      await new Promise((resolve) => {
+        setTimeout(resolve, Math.random() * 3000 + 500);
+      });
+
+      const response = await fetch(`https://api.github.com/repos/cilium/cilium`);
+      const { stargazers_count } = await response.json();
+      if (!stargazers_count) {
+        throw new Error('Failed to fetch GitHub stars');
+      }
+      stars = new Intl.NumberFormat('en-US').format(stargazers_count);
+
+      await cache.set(cacheKey, {
+        stars,
+        created: Date.now(),
+      });
     }
-    stars = new Intl.NumberFormat('en-US').format(stargazers_count);
-    await cache.set(cacheKey, {
-      stars,
-      created: Date.now(),
-    });
+  } catch (error) {
+    console.log(error);
+    throw new Error('Failed to fetch GitHub stars');
   }
 
   createNode({
@@ -237,4 +275,25 @@ exports.sourceNodes = async ({ actions: { createNode }, createContentDigest, cac
       contentDigest: createContentDigest(stars),
     },
   });
+}
+
+exports.sourceNodes = async (options) => {
+  await getHubspotEmails(options);
+  await getGithubStars(options);
+};
+
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions;
+  const typeDefs = `
+    type HubspotEmails implements Node {
+      objects: [HubspotEmailsObject]
+    }
+    type HubspotEmailsObject {
+      name: String
+      publishDate: String
+      isPublished: Boolean
+      publishedUrl: String
+    }
+  `;
+  createTypes(typeDefs);
 };

--- a/src/components/shared/github-stars/github-stars.jsx
+++ b/src/components/shared/github-stars/github-stars.jsx
@@ -11,7 +11,7 @@ const GithubStars = ({ className }) => {
     githubStars: { githubStars },
   } = useStaticQuery(graphql`
     query githubQuery {
-      githubStars(id: { eq: "github-stars-cilium" }) {
+      githubStars {
         githubStars
       }
     }

--- a/src/components/shared/github-stars/github-stars.jsx
+++ b/src/components/shared/github-stars/github-stars.jsx
@@ -7,9 +7,13 @@ import GithubLogo from 'icons/github.inline.svg';
 import Link from '../link';
 
 const GithubStars = ({ className }) => {
-  const data = useStaticQuery(graphql`
+  const {
+    githubStars: { githubStars },
+  } = useStaticQuery(graphql`
     query githubQuery {
-      githubStars
+      githubStars(id: { eq: "github-stars-cilium" }) {
+        githubStars
+      }
     }
   `);
 
@@ -28,7 +32,7 @@ const GithubStars = ({ className }) => {
           <span>GitHub Stars</span>
         </div>
         <div className="px-2 text-black xs:px-3">
-          <span>{`${(parseInt(data.githubStars.replace(/,/g, '')) / 1000).toFixed(1)}k`}</span>
+          <span>{`${(parseInt(githubStars.replace(/,/g, ''), 10) / 1000).toFixed(1)}k`}</span>
         </div>
       </Link>
     </div>


### PR DESCRIPTION
This pull request brings the update for github stars node, replacing `createResolvers` with `sourceNodes`. According to Gatsby docs, with v4 creating nodes inside `createResolvers` is not allowed. ([More info](https://www.gatsbyjs.com/docs/reference/release-notes/migrating-source-plugin-from-v3-to-v4/#2-data-mutations-need-to-happen-during-sourcenodes-or-oncreatenode)) 