### PR TITLE
fix: replace hubspot api key with access token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ GATSBY_ALGOLIA_SEARCH_KEY=
 ALGOLIA_ADMIN_KEY=
 GATSBY_ALGOLIA_INDEX_NAME=
 
-HUBSPOT_API_KEY=
+HUBSPOT_ACCESS_TOKEN=
 
 # Secret keys of Algolia are available in algolia account
 # or netlify environment variables.

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -202,6 +202,7 @@ exports.sourceNodes = async ({ actions: { createNode }, createContentDigest }) =
         hubspotEmailsData = await hubspotEmails.json();
       } catch (error) {
         console.log(error);
+        return [];
       }
 
       return hubspotEmailsData.objects

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -186,11 +186,27 @@ exports.onCreateNode = ({ node, actions }) => {
 
 exports.sourceNodes = async ({ actions: { createNode }, createContentDigest }) => {
   const hubspotEmails = await fetch(
-    `https://api.hubapi.com/marketing-emails/v1/emails?hapikey=${process.env.HUBSPOT_API_KEY}&limit=150&name__icontains=eCHO+news&orderBy=-publish_date`
+    `https://api.hubapi.com/marketing-emails/v1/emails?limit=150&name__icontains=eCHO+news&orderBy=-publish_date`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${process.env.HUBSPOT_ACCESS_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+    }
   );
   const hubspotEmailsData = await hubspotEmails.json();
+  const objects = hubspotEmailsData.objects.map(
+    ({ name, publishDate, isPublished, publishedUrl }) => ({
+      name,
+      publishDate,
+      isPublished,
+      publishedUrl,
+    })
+  );
+
   createNode({
-    objects: hubspotEmailsData.objects,
+    objects,
     id: `hubspot-email-data`,
     parent: null,
     children: [],

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -184,9 +184,18 @@ exports.onCreateNode = ({ node, actions }) => {
   }
 };
 
+function getMockEmailsData() {
+  return Array.from({ length: 3 }).map((_, i) => ({
+    name: `eCHO news ${i + 1}`,
+    publishDate: new Date(Date.now() - Math.floor(Math.random() * 10e9)).toISOString(),
+    isPublished: false,
+    publishedUrl: '/',
+  }));
+}
+
 exports.sourceNodes = async ({ actions: { createNode }, createContentDigest }) => {
   const getObjects = async () => {
-    if (process.env.HUBSPOT_ACCESS_TOKEN) {
+    if (process.env.NODE_ENV === 'production' && process.env.HUBSPOT_ACCESS_TOKEN) {
       const hubspotEmails = await fetch(
         `https://api.hubapi.com/marketing-emails/v1/emails?limit=150&name__icontains=eCHO+news&orderBy=-publish_date`,
         {
@@ -208,18 +217,13 @@ exports.sourceNodes = async ({ actions: { createNode }, createContentDigest }) =
     }
 
     // in case of HUBSPOT_ACCESS_TOKEN lack, return an stub array
-    return Array.from({ length: 3 }).map((_, i) => ({
-      name: `eCHO news ${i + 1}`,
-      publishDate: new Date(Date.now() - Math.floor(Math.random() * 10000000000)).toISOString(),
-      isPublished: false,
-      publishedUrl: '/',
-    }));
+    return getMockEmailsData();
   };
 
   const objects = await getObjects();
 
   createNode({
-    objects,
+    objects: objects.length ? objects : getMockEmailsData(),
     id: `hubspot-email-data`,
     parent: null,
     children: [],

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -186,18 +186,23 @@ exports.onCreateNode = ({ node, actions }) => {
 
 exports.sourceNodes = async ({ actions: { createNode }, createContentDigest }) => {
   const getObjects = async () => {
-    if (process.env.HUBSPOT_ACCESS_TOKEN) {
-      const hubspotEmails = await fetch(
-        `https://api.hubapi.com/marketing-emails/v1/emails?limit=150&name__icontains=eCHO+news&orderBy=-publish_date`,
-        {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${process.env.HUBSPOT_ACCESS_TOKEN}`,
-            'Content-Type': 'application/json',
-          },
-        }
-      );
-      const hubspotEmailsData = await hubspotEmails.json();
+    if (process.env.NODE_ENV === 'production' && process.env.HUBSPOT_ACCESS_TOKEN) {
+      let hubspotEmailsData;
+      try {
+        const hubspotEmails = await fetch(
+          `https://api.hubapi.com/marketing-emails/v1/emails?limit=150&name__icontains=eCHO+news&orderBy=-publish_date`,
+          {
+            method: 'GET',
+            headers: {
+              Authorization: `Bearer ${process.env.HUBSPOT_ACCESS_TOKEN}`,
+              'Content-Type': 'application/json',
+            },
+          }
+        );
+        hubspotEmailsData = await hubspotEmails.json();
+      } catch (error) {
+        console.log(error);
+      }
 
       return hubspotEmailsData.objects
         .filter(({ isPublished }) => isPublished !== false)

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -199,15 +199,12 @@ exports.sourceNodes = async ({ actions: { createNode }, createContentDigest }) =
       );
       const hubspotEmailsData = await hubspotEmails.json();
 
-      const objects = hubspotEmailsData.objects.map(
-        ({ name, publishDate, isPublished, publishedUrl }) => ({
-          name,
-          publishDate,
-          isPublished,
-          publishedUrl,
-        })
-      );
-      return objects;
+      return hubspotEmailsData.objects.map(({ name, publishDate, isPublished, publishedUrl }) => ({
+        name,
+        publishDate,
+        isPublished,
+        publishedUrl,
+      }));
     }
 
     // in case of HUBSPOT_ACCESS_TOKEN lack, return an stub array

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -186,7 +186,7 @@ exports.onCreateNode = ({ node, actions }) => {
 
 exports.sourceNodes = async ({ actions: { createNode }, createContentDigest }) => {
   const getObjects = async () => {
-    if (process.env.NODE_ENV === 'production' && process.env.HUBSPOT_ACCESS_TOKEN) {
+    if (process.env.HUBSPOT_ACCESS_TOKEN) {
       const hubspotEmails = await fetch(
         `https://api.hubapi.com/marketing-emails/v1/emails?limit=150&name__icontains=eCHO+news&orderBy=-publish_date`,
         {
@@ -211,7 +211,7 @@ exports.sourceNodes = async ({ actions: { createNode }, createContentDigest }) =
     return Array.from({ length: 3 }).map((_, i) => ({
       name: `eCHO news ${i + 1}`,
       publishDate: new Date(Date.now() - Math.floor(Math.random() * 10000000000)).toISOString(),
-      isPublished: true,
+      isPublished: false,
       publishedUrl: '/',
     }));
   };

--- a/src/components/pages/newsletter/issues/issues.jsx
+++ b/src/components/pages/newsletter/issues/issues.jsx
@@ -45,7 +45,7 @@ const Issues = () => {
 
   const newsletterData = getIssues();
 
-  return (
+  return Object.keys(newsletterData).length > 0 ? (
     <div className="bg-white py-10 md:py-20 lg:py-28" id="archive">
       <Container>
         {Object.entries(newsletterData).map(([year, issues], index) => (
@@ -76,7 +76,7 @@ const Issues = () => {
         ))}
       </Container>
     </div>
-  );
+  ) : null;
 };
 
 export default Issues;

--- a/src/components/pages/newsletter/issues/issues.jsx
+++ b/src/components/pages/newsletter/issues/issues.jsx
@@ -16,21 +16,18 @@ const Issues = () => {
         objects {
           name
           publishDate
-          isPublished
           publishedUrl
         }
       }
     }
   `);
 
-  const items = data.hubspotEmails.objects.filter(
-    (item) => item.name.match(/^eCHO news \d{1,3}$/) && item.isPublished
-  );
+  const items = data.hubspotEmails.objects.filter((item) => item.name.match(/^eCHO news \d{1,3}$/));
 
   items.forEach((item) => {
-    item.year = getYear(item.publishDate);
+    item.year = getYear(Number(item.publishDate));
     item.title = `eCHO News Episode #${item.name.split(' ')[2]}`;
-    item.date = getMonthAndDay(item.publishDate);
+    item.date = getMonthAndDay(Number(item.publishDate));
   });
 
   const getIssues = () =>


### PR DESCRIPTION
This pull request replaces the Hubspot API key with an access token as [API keys are being deprecated November 30.](https://developers.hubspot.com/changelog/upcoming-api-key-sunset)

**TODO**
- [x] add `HUBSPOT_ACCESS_TOKEN` as an environment variable to netlify. 