### PR TITLE
feat: add anchors to sections on Adopters page

### DIFF
--- a/src/components/pages/adopters/logos/logos.jsx
+++ b/src/components/pages/adopters/logos/logos.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import Container from 'components/shared/container';
 import Heading from 'components/shared/heading';
+import Link from 'components/shared/link';
 
 import AlibabaCloudLogo from './images/alibaba-cloud.inline.svg';
 import AmazonEKSlogo from './images/amazon-eks.inline.svg';
@@ -78,12 +79,12 @@ const spaceXClassNames = {
   md: 'mx-4 md:mx-6 lg:mx-8',
 };
 
-const Logos = ({ title, items, spaceXSize }) => (
-  <section className="mt-10 md:mt-20 lg:mt-28 xl:mt-32">
+const Logos = ({ title, items, spaceXSize, id }) => (
+  <section className="pt-10 md:pt-20 lg:pt-28 xl:pt-32" id={id}>
     <Container size="md">
-      <Heading className="text-center" tag="h2">
-        {title}
-      </Heading>
+      <Link className="text-center" to={`#${id}`}>
+        <Heading tag="h2">{title}</Heading>
+      </Link>
       <div className="mx-0 mt-4 flex flex-wrap justify-center md:mt-6 lg:mx-[-26px] lg:mt-8">
         {items.map((logo, index) => {
           const Logo = logos[logo];
@@ -103,9 +104,14 @@ const Logos = ({ title, items, spaceXSize }) => (
 );
 
 Logos.propTypes = {
+  id: PropTypes.string,
   title: PropTypes.string.isRequired,
   items: PropTypes.arrayOf(PropTypes.string).isRequired,
   spaceXSize: PropTypes.oneOf(Object.keys(spaceXClassNames)).isRequired,
+};
+
+Logos.defaultProps = {
+  id: null,
 };
 
 export default Logos;

--- a/src/components/shared/user-community/user-community.jsx
+++ b/src/components/shared/user-community/user-community.jsx
@@ -188,16 +188,19 @@ const UserCommunity = ({
   buttonText,
   buttonUrl,
   buttonTarget,
+  id,
 }) => (
-  <section className={classNames(className, themeClassNames[theme].wrapper)}>
+  <section className={classNames(className, themeClassNames[theme].wrapper)} id={id}>
     <Container className="flex flex-col">
       {title && (
-        <Heading
-          className={classNames(isTitleCentered && 'mb-6 text-center md:mb-10 lg:mb-16')}
-          tag="h3"
+        <Link
+          className={classNames(
+            isTitleCentered && 'mb-6 self-center text-center md:mb-10 lg:mb-16'
+          )}
+          to={`#${id}`}
         >
-          {title}
-        </Heading>
+          <Heading tag="h3">{title}</Heading>
+        </Link>
       )}
       <div
         className={classNames(
@@ -276,6 +279,7 @@ UserCommunity.propTypes = {
   buttonText: PropTypes.string,
   buttonUrl: PropTypes.string,
   buttonTarget: PropTypes.string,
+  id: PropTypes.string,
 };
 
 UserCommunity.defaultProps = {
@@ -286,6 +290,7 @@ UserCommunity.defaultProps = {
   buttonText: null,
   buttonUrl: null,
   buttonTarget: null,
+  id: null,
 };
 
 export default UserCommunity;

--- a/src/pages/adopters.jsx
+++ b/src/pages/adopters.jsx
@@ -249,11 +249,12 @@ const Adopters = () => (
   <MainLayout theme="gray">
     <HeroWithoutImage {...hero} />
     <UserCommunity className="pt-6 pb-10 md:pt-10 md:pb-20 lg:pt-14 lg:pb-32" {...userCommunity1} />
-    <Logos {...logos1} />
-    <Logos {...logos2} />
+    <Logos {...logos1} id="preferred-cloud" />
+    <Logos {...logos2} id="kubernetes-distribution" />
     <UserCommunity
       className="mt-10 py-10 md:mt-20 md:py-20 lg:mt-28 lg:py-28"
       {...userCommunity2}
+      id="cilium-is-everywhere"
     />
   </MainLayout>
 );


### PR DESCRIPTION
This pull request brings anchors for the sections on Adopters page
- Deploy on your preferred cloud: `#preferred-cloud`
- Use your favorite Kubernetes distribution: `#kubernetes-distribution`
- Cilium is everywhere: `cilium-is-everywhere`