### PR TITLE
feat: move clickhouse to the top section

### DIFF
--- a/src/pages/adopters.jsx
+++ b/src/pages/adopters.jsx
@@ -119,6 +119,7 @@ const hero = {
 const userCommunity1 = {
   theme: 'gray',
   items: [
+    clickhouse,
     tietoevry,
     bloomberg,
     azure,
@@ -225,7 +226,6 @@ const userCommunity2 = {
     polverio,
     polarsignals,
     daimlertruck,
-    clickhouse,
     proton,
     cistec,
     kubehetzner,

--- a/src/utils/case-studies-data.js
+++ b/src/utils/case-studies-data.js
@@ -493,6 +493,17 @@ export default {
       },
     ],
   },
+  clickhouse: {
+    iconName: 'clickhouse',
+    text: 'ClickHouse uses Cilium as CNI for AWS Kubernetes environments',
+    links: [
+      {
+        linkText: 'Read Case Study',
+        linkUrl: 'https://www.cncf.io/case-studies/clickhouse/',
+        linkTarget: '_blank',
+      },
+    ],
+  },
   kubesphere: {
     iconName: 'kubesphere',
     text: '<b>KubeKey</b> is an open-source lightweight tool for deploying Kubernetes clusters and addons',
@@ -712,10 +723,6 @@ export default {
   daimlertruck: {
     iconName: 'daimlertruck',
     text: '<b>Daimler Truck</b> is maintaining an AKS k8s cluster as a shared resource for DevOps crews and is using Cilium as the default CNI',
-  },
-  clickhouse: {
-    iconName: 'clickhouse',
-    text: '<b>ClickHouse</b> uses Cilium as CNI for AWS Kubernetes environments',
   },
   proton: {
     iconName: 'proton',

--- a/src/utils/case-studies-data.js
+++ b/src/utils/case-studies-data.js
@@ -495,7 +495,7 @@ export default {
   },
   clickhouse: {
     iconName: 'clickhouse',
-    text: 'ClickHouse uses Cilium as CNI for AWS Kubernetes environments',
+    text: 'ClickHouse uses Cilium and Hubble across multiple clouds',
     links: [
       {
         linkText: 'Read Case Study',


### PR DESCRIPTION
**This PR:**
Add the clickhouse card to the top section of the Adopters page;

**Steps to test**

- Open the [Adopters page](https://deploy-preview-280--cilium.netlify.app/adopters/)
- Confirm that everything looks and works as expected