### PR TITLE
Update site metadata

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -238,9 +238,9 @@ if (process.env.CONTEXT === 'production') {
 module.exports = {
   trailingSlash: 'always',
   siteMetadata: {
-    siteTitle: 'Cilium - Linux Native, API-Aware Networking and Security for Containers', // <title>
+    siteTitle: 'Cilium - Cloud Native, eBPF-based Networking, Observability, and Security', // <title>
     siteDescription:
-      'Linux-Native, API-Aware Networking and Security for Containers. Open source project, Fork me on Github',
+      'Cloud Native, eBPF-based Networking, Observability, and Security',
     // pathPrefix: "",
     siteImage: '/images/social-preview.jpg',
     siteLanguage: 'en',


### PR DESCRIPTION
Cilium is cloud native - and not just Linux any more! This change updates the text that gets shown when we link to cilium.io (for example I came across it in the CNCF Slack) 
<img width="483" alt="Screenshot 2023-06-09 at 09 52 47" src="https://github.com/cilium/cilium.io/assets/458616/eecbb128-101e-48b0-8f79-78d48b408684">
