### PR TITLE
add case study to bloomberg card

### DIFF
--- a/src/utils/case-studies-data.js
+++ b/src/utils/case-studies-data.js
@@ -458,7 +458,7 @@ export default {
       },
       {
         linkText: 'User Story',
-        linkUrl: 'https://www.cncf.io/case-studies/bloomberg-2/?linkId=226868517',
+        linkUrl: 'https://www.cncf.io/case-studies/bloomberg-2/',
         linkTarget: '_blank',
       },
     ],

--- a/src/utils/case-studies-data.js
+++ b/src/utils/case-studies-data.js
@@ -452,8 +452,13 @@ export default {
     text: 'Bloomberg leverages Cilium to construct data sandboxes that restrict users from distributing data outside the sandbox',
     links: [
       {
-        linkText: 'Watch video',
+        linkText: 'Video',
         linkUrl: 'https://www.youtube.com/watch?v=8fiYVyISyz4/',
+        linkTarget: '_blank',
+      },
+      {
+        linkText: 'User Story',
+        linkUrl: 'https://www.cncf.io/case-studies/bloomberg-2/?linkId=226868517',
         linkTarget: '_blank',
       },
     ],


### PR DESCRIPTION
This PR:
Adds case study to Bloomberg card in the top section of the Adopters page;

Steps to test

Open the [Adopters page](https://deploy-preview-319--cilium.netlify.app/adopters/)
Confirm that everything looks and works as expected