### PR TITLE
Adding Performance Impact of Sidecar in the CNI benchmark Blog

### DIFF
--- a/src/posts/2021-05-11-cni-benchmark/index.md
+++ b/src/posts/2021-05-11-cni-benchmark/index.md
@@ -481,7 +481,7 @@ The difference in latency is much more significant than the consumed CPU:
 
 # Performance Impact of Sidecars on a Service Mesh
 
-Besides avoiding the sheer amount of proxies that need to be run in a sidecar model, a significant advantage of a sidecar-free model is that we can avoid the requirement to run two proxies in between any connection. This is made possible by using Cilium at the network/node level to encrypt and authenticate or use the upcoming new mTLS model which separates the authentication from the transport. More details in this blog [Next-Generation Mutual Authentication with Cilium Service Mesh](https://isovalent.com/blog/post/2022-05-03-servicemesh-security/)
+Besides avoiding the sheer amount of proxies that need to be run in a sidecar service mesh model, a significant advantage of sidecarless service mesh is that we can avoid requiring running two proxies in between any connection. More details about Cilium's sidecarless service mesh can be found in this blog [Next-Generation Mutual Authentication with Cilium Service Mesh](https://isovalent.com/blog/post/2022-05-03-servicemesh-security/)
 
 ![](images/performance_impact_sidecar.png)
 

--- a/src/posts/2021-05-11-cni-benchmark/index.md
+++ b/src/posts/2021-05-11-cni-benchmark/index.md
@@ -479,7 +479,7 @@ The difference in latency is much more significant than the consumed CPU:
 
 <a name="env"></a>
 
-# Performance Impact of a Sidecar
+# Performance Impact of Sidecars on a Service Mesh
 
 Besides avoiding the sheer amount of proxies that need to be run in a sidecar model, a significant advantage of a sidecar-free model is that we can avoid the requirement to run two proxies in between any connection. This is made possible by using Cilium at the network/node level to encrypt and authenticate or use the upcoming new mTLS model which separates the authentication from the transport. More details in this blog [Next-Generation Mutual Authentication with Cilium Service Mesh](https://isovalent.com/blog/post/2022-05-03-servicemesh-security/)
 

--- a/src/posts/2021-05-11-cni-benchmark/index.md
+++ b/src/posts/2021-05-11-cni-benchmark/index.md
@@ -48,6 +48,7 @@ the topic of container networking benchmarking a bit deeper and look at:
 - [Rate of new Connections](#crr)
 - [The Cost of Encryption - Wireguard vs IPsec](#encryption)
 - [How to reproduce the results](#env)
+- [Performance Impact of a Sidecar](#sidecar)
 
 <a name="summary"></a>
 
@@ -477,6 +478,16 @@ The difference in latency is much more significant than the consumed CPU:
 ![](images/bench_wireguard_ipsec_tcp_rr_1_process_cpu.png)
 
 <a name="env"></a>
+
+# Performance Impact of a Sidecar
+
+Besides avoiding the sheer amount of proxies that need to be run in a sidecar model, a significant advantage of a sidecar-free model is that we can avoid the requirement to run two proxies in between any connection. This is made possible by using Cilium at the network/node level to encrypt and authenticate or use the upcoming new mTLS model which separates the authentication from the transport. More details in this blog [Next-Generation Mutual Authentication with Cilium Service Mesh](https://isovalent.com/blog/post/2022-05-03-servicemesh-security/)
+
+![](images/performance_impact_sidecar.png)
+
+Reducing the number of proxies in the network path and choosing the type of Envoy filter has a significant impact on performance.  The above benchmark illustrates the latency cost of HTTP processing with a single Envoy proxy running the Cilium Envoy filter (brown) compared to a two-sidecar Envoy model running the Istio Envoy filter (blue). Yellow is the baseline latency with no proxy with no HTTP processing performed.
+
+<a name="sidecar"></a>
 
 # Test Environment
 

--- a/src/posts/2021-05-11-cni-benchmark/index.md
+++ b/src/posts/2021-05-11-cni-benchmark/index.md
@@ -485,7 +485,7 @@ Besides avoiding the sheer amount of proxies that need to be run in a sidecar mo
 
 ![](images/performance_impact_sidecar.png)
 
-Reducing the number of proxies in the network path and choosing the type of Envoy filter has a significant impact on performance.  The above benchmark illustrates the latency cost of HTTP processing with a single Envoy proxy running the Cilium Envoy filter (brown) compared to a two-sidecar Envoy model running the Istio Envoy filter (blue). Yellow is the baseline latency with no proxy with no HTTP processing performed.
+Reducing the number of proxies in the network path and choosing the type of Envoy filter has a significant impact on performance.  The above benchmark illustrates the latency cost of HTTP processing with a single Envoy proxy running the Cilium Envoy filter (brown) compared to a two-sidecar Envoy model running the Istio Envoy filter (blue). Yellow is the baseline latency with no proxy and no HTTP processing performed.
 
 <a name="sidecar"></a>
 


### PR DESCRIPTION
Adding Performance Impact of Sidecar in the CNI benchmark Blog as a step to enhance cross blog visibility.

Adding numbers from https://isovalent.com/blog/post/cilium-service-mesh/ to https://cilium.io/blog/2021/05/11/cni-benchmark/ as a first step.