### PR TITLE
Add note on version of sw used

### DIFF
--- a/src/posts/2022-07-13-L4LB-XDP/index.md
+++ b/src/posts/2022-07-13-L4LB-XDP/index.md
@@ -75,7 +75,7 @@ WantedBy=multi-user.target
 
 ```
 
-and then we launched Cilium in load balancer only mode:
+and then we launched Cilium in load balancer only mode, below is our configuration from the (Cilium 1.10 version)[https://cilium.io/blog/2021/05/20/cilium-110#standalonelb]:
 
 ```
 systemctl start sys-fs-bpf.mount; docker run \


### PR DESCRIPTION
Added note to explicitly call out provided config is from version 1.10, to help avoid issues such as mentioned in this cilium slack message > https://cilium.slack.com/archives/C1MATJ5U5/p1696355257581019