### PR TITLE
fix: typo ("the Cilium")

### DIFF
--- a/src/components/pages/get-started/learn/learn.jsx
+++ b/src/components/pages/get-started/learn/learn.jsx
@@ -18,7 +18,7 @@ const items = [
     },
 
     name: '10min Introduction to Cilium',
-    text: `Liz Rice and Thomas Graf answer the most popular questions about the Cilium, its creation and the problems it solves`,
+    text: `Liz Rice and Thomas Graf answer the most popular questions about Cilium, its creation and the problems it solves`,
     buttons: [
       {
         url: 'https://www.youtube.com/watch?v=80OYrzS1dCA&t=405s',


### PR DESCRIPTION
No need for an article before "Cilium", let's change "the Cilium" to simply "Cilium".