### PR TITLE
Re-release the blog post (sw over hw)

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -16,7 +16,6 @@ const plugins = [
     options: {
       name: `posts`,
       path: `${__dirname}/src/posts`,
-      ignore: [`**/2024-02-12-how-software-networking-is-taking-over-the-world`],
     },
   },
   {


### PR DESCRIPTION
This removes the `ignore` line that is hiding the blog post from Monday about software over hardware networking.