### PR TITLE
fix: event cards cover

### DIFF
--- a/src/components/pages/events/events-board/event-card/event-card.jsx
+++ b/src/components/pages/events/events-board/event-card/event-card.jsx
@@ -18,7 +18,7 @@ const EventCover = ({ ogImage, title }) => {
 
   return ogImage ? (
     <GatsbyImage
-      imgClassName="self-center rounded-t-lg h-full max-h-[261px] sm:max-h-[221px] lg:max-h-[180px]"
+      className="h-[261px] rounded-t-lg lg:h-[180px] sm:h-[221px]"
       image={getImage(ogImage)}
       objectFit="cover"
       alt={title}


### PR DESCRIPTION
**Describe what changes this pull request brings**

Fix default cover's size for event cards

| before | after |
|---|---|
| <img width="624" alt="image" src="https://github.com/user-attachments/assets/0c81b2f8-f115-435b-8d70-e73acf4baabd"> | <img width="619" alt="image" src="https://github.com/user-attachments/assets/989498eb-379e-402b-8df3-0b74cbd4335d"> |


**Steps to check:**

1. Open [preview](https://deploy-preview-550--cilium.netlify.app/events/)
2. Make sure that everything looks and works as expected