### PR TITLE
fix(hooks): move event handler inside useEffect for linter compliance

### DIFF
--- a/src/hooks/use-click-outside.js
+++ b/src/hooks/use-click-outside.js
@@ -2,17 +2,17 @@ import { useEffect } from 'react';
 
 const events = [`mousedown`, `touchstart`];
 export default (refs, onClickOutside) => {
-  const isOutside = (element) =>
-    refs.every((ref) => !ref.current || !ref.current.contains(element));
-  const onClick = (event) => {
-    if (isOutside(event.target)) {
-      onClickOutside();
-    }
-  };
   useEffect(() => {
+    const isOutside = (element) =>
+      refs.every((ref) => !ref.current || !ref.current.contains(element));
+    const onClick = (event) => {
+      if (isOutside(event.target)) {
+        onClickOutside();
+      }
+    };
     events.forEach((event) => document.addEventListener(event, onClick));
     return () => {
       events.forEach((event) => document.removeEventListener(event, onClick));
     };
-  });
+  }, [refs, onClickOutside]);
 };


### PR DESCRIPTION
## Description
The custom hook use-click-outside was previously adding event listeners in a useEffect without proper dependency management. The event handler (onClick) was defined outside the effect, and the effect’s dependency array did not include it. When the dependency array was added, the linter flagged that onClick was being re-created on every render, causing the effect to re-run unnecessarily and potentially leading to performance issues or memory leaks.

Issue-#616
Related PR- #617 

### What’s fixed now?
- The event handler (onClick) and the helper (isOutside) are now defined inside the useEffect hook.
- The effect’s dependency array now only includes refs and onClickOutside, both of which are stable in all usages across the codebase.
- This ensures event listeners are only added/removed when necessary, prevents memory leaks, and fully satisfies React and ESLint best practices.

This prevents potential memory leaks and performance issues.