### PR TITLE
fix: add post about Cilium 1.15 and 1.16 on Release Categories

### DIFF
--- a/src/posts/2024-02-01-cilium-1-15-isovalent/index.md
+++ b/src/posts/2024-02-01-cilium-1-15-isovalent/index.md
@@ -7,4 +7,5 @@ ogSummary: 'Cilium 1.15 has arrived with Gateway API 1.0 Support, Cluster Mesh S
 externalUrl: 'https://isovalent.com/blog/post/cilium-1-15/?utm_source=website-cilium&utm_medium=referral&utm_campaign=cilium-blog'
 categories:
   - Community
+  - Release
 ---

--- a/src/posts/2024-07-25-cilium-1-1-6/index.md
+++ b/src/posts/2024-07-25-cilium-1-1-6/index.md
@@ -6,5 +6,6 @@ ogSummary: 'Cilium 1.16 has arrived with Netkit, Gateway API Gamma Support, Mult
 externalUrl: 'https://isovalent.com/blog/post/cilium-1-16/'
 isPopular: true
 categories:
+  - Release
   - Technology
 ---


### PR DESCRIPTION
Add missing Release Categories for blog post about Cilium 1.15 and 1.16 when coming from doc about release cadence (https://docs.cilium.io/en/stable/community/roadmap/#release-cadence)