### PR TITLE
Fix Horizontal scrolling bug in adopters route

### DIFF
--- a/src/pages/adopters.jsx
+++ b/src/pages/adopters.jsx
@@ -444,13 +444,16 @@ const logos2 = {
 };
 
 const Adopters = () => (
-  <MainLayout theme="gray">
+  <MainLayout className="overflow-x-hidden" theme="gray">
     <HeroWithoutImage {...hero} />
-    <UserCommunity className="pt-6 pb-10 md:pt-10 md:pb-20 lg:pt-14 lg:pb-32" {...userCommunity1} />
+    <UserCommunity
+      className="pt-6 pb-10 md:pt-10 md:pb-20 lg:pt-14 lg:pb-32 overflow-x-scroll max-w-full"
+      {...userCommunity1}
+    />
     <Logos {...logos1} id="preferred-cloud" />
     <Logos {...logos2} id="kubernetes-distribution" />
     <UserCommunity
-      className="mt-10 py-10 md:mt-20 md:py-20 lg:mt-28 lg:py-28"
+      className="mt-10 py-10 md:mt-20 md:py-20 lg:mt-28 lg:py-28 overflow-x-scroll max-w-full"
       {...userCommunity2}
       id="cilium-is-everywhere"
     />


### PR DESCRIPTION
This PR fixes the issue #650 

**What it does** 

- Add overflow-x-hidden to the whole page to prevent scrolling
- Add w-full to acquire the full width of the screen

**Screenshot showing a page without horizontal scrolling**

<img width="1919" height="1045" alt="Screenshot 2025-07-16 090448" src="https://github.com/user-attachments/assets/1028a93c-5ba0-4a53-b10c-9493251e9acb" />
