### PR TITLE
bug: Fix duplicate event listeners in useClickOutside hook

### DIFF
--- a/src/hooks/use-click-outside.js
+++ b/src/hooks/use-click-outside.js
@@ -4,15 +4,15 @@ const events = [`mousedown`, `touchstart`];
 export default (refs, onClickOutside) => {
   const isOutside = (element) =>
     refs.every((ref) => !ref.current || !ref.current.contains(element));
-  const onClick = (event) => {
-    if (isOutside(event.target)) {
-      onClickOutside();
-    }
-  };
   useEffect(() => {
+    const onClick = (event) => {
+      if (isOutside(event.target)) {
+        onClickOutside();
+      }
+    };
     events.forEach((event) => document.addEventListener(event, onClick));
     return () => {
       events.forEach((event) => document.removeEventListener(event, onClick));
     };
-  });
+  }, []);
 };


### PR DESCRIPTION
Closes: #617, #619 

The [use-click-outside.js](https://github.com/cilium/cilium.io/blob/main/src/hooks/use-click-outside.js#L12) was registering multiple event listeners on every render, causing the handler function to run multiple times per click which is unnecessary and bad code.

Solution: Uses empty dependency array to register listeners only once.