### PR TITLE
fix: add missing metadata for homepage (#676)

### DIFF
--- a/src/utils/seo-metadata.js
+++ b/src/utils/seo-metadata.js
@@ -1,10 +1,14 @@
 const enterprise = {
-  // title: 'Cilium - Enterprise Distributions & Training',
+  title: 'Cilium - Enterprise Distributions & Training Partners',
   description:
     'Learn how to get enterprise level support and training for Cilium from different vendors in the ecosystem',
 };
+const homepage = {
+  title: 'Cilium - eBPF-based Networking for Kubernetes',
+  description: 'Cilium provides eBPF-based networking, security policies, and observability for Kubernetes. Trusted by Google GKE, AWS EKS, and cloud native platforms worldwide.',
+};
 const learn = {
-  // title: 'Cilium - What is Cilium?',
+  title: 'Cilium - What is Cilium?',
   description:
     'Cilium is an open source project to provide networking, security, and observability for cloud native environments such as Kubernetes clusters and other container orchestration platforms.',
 };
@@ -42,4 +46,4 @@ const newsletter = {
     'If you want to keep up on the latest in cloud native networking, observability, and security this is your source',
 };
 
-export { enterprise, learn, adopters, getHelp, getInvolved, tellingStory, newsletter, brand };
+export { enterprise, learn, adopters, getHelp, getInvolved, tellingStory, newsletter, brand,homepage };

--- a/src/utils/seo-metadata.js
+++ b/src/utils/seo-metadata.js
@@ -4,7 +4,7 @@ const enterprise = {
     'Learn how to get enterprise level support and training for Cilium from different vendors in the ecosystem',
 };
 const homepage = {
-  title: 'Cilium - eBPF-based Networking for Kubernetes',
+  title: 'Cilium - eBPF-based Networking, Observability, and Security for Kubernetes',
   description: 'Cilium provides eBPF-based networking, security policies, and observability for Kubernetes. Trusted by Google GKE, AWS EKS, and cloud native platforms worldwide.',
 };
 const learn = {

--- a/src/utils/seo-metadata.js
+++ b/src/utils/seo-metadata.js
@@ -46,4 +46,4 @@ const newsletter = {
     'If you want to keep up on the latest in cloud native networking, observability, and security this is your source',
 };
 
-export { enterprise, learn, adopters, getHelp, getInvolved, tellingStory, newsletter, brand,homepage };
+export { enterprise, learn, adopters, getHelp, getInvolved, tellingStory, newsletter, brand, homepage };

--- a/src/utils/seo-metadata.js
+++ b/src/utils/seo-metadata.js
@@ -5,7 +5,7 @@ const enterprise = {
 };
 const homepage = {
   title: 'Cilium - eBPF-based Networking, Observability, and Security for Kubernetes',
-  description: 'Cilium provides eBPF-based networking, security policies, and observability for Kubernetes. Trusted by Google GKE, AWS EKS, and cloud native platforms worldwide.',
+  description: 'Cilium provides eBPF-based networking, observability, and security for Kubernetes and beyond. Trusted by all major cloud providers and cloud native platforms worldwide.',
 };
 const learn = {
   title: 'Cilium - What is Cilium?',


### PR DESCRIPTION
Added the metadata for homePage in src/utils/metadata.js
this fix #676 