### PR TITLE
Fix: Dark Mode Flicker on Page Reload

### DIFF
--- a/src/hooks/use-dark-mode.js
+++ b/src/hooks/use-dark-mode.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 const useDarkMode = () => {
   const [isDarkMode, setIsDarkMode] = useState(false);
+  const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
     const updateDarkMode = () => {
@@ -19,6 +20,7 @@ const useDarkMode = () => {
       }
 
       updateDarkMode();
+      setIsReady(true);
     };
 
     initializeTheme();
@@ -41,7 +43,7 @@ const useDarkMode = () => {
     };
   }, []);
 
-  return isDarkMode;
+  return { isDarkMode, isReady };
 };
 
 export default useDarkMode;

--- a/src/layouts/main/main.jsx
+++ b/src/layouts/main/main.jsx
@@ -22,7 +22,11 @@ const MainLayout = ({ children, headerWithSearch, footerWithTopBorder }) => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const toggleTheme = useToggleTheme();
-  const isDarkMode = useDarkMode();
+  const { isDarkMode, isReady } = useDarkMode();
+
+  if (!isReady) {
+    return null;
+  }
 
   const navigation = [
     { name: 'Users', href: '/adopters' },


### PR DESCRIPTION
## Description

This pull request resolves [#678](https://github.com/cilium/cilium.io/issues/678) — **Dark Mode Flicker on Initial Page Load**.  

## Changes Introduced

- Introduced a `useDarkMode` hook that:
  - Detects current dark mode preference.
  - Waits for client-side hydration before rendering the UI.
- Deferred component rendering using an `isReady` flag to avoid incorrect theme flash.


## Demo
> 

https://github.com/user-attachments/assets/1b802419-d38d-4b03-9a6b-378d2973c5e5

Closes [#678 ](https://github.com/cilium/cilium.io/issues/678)
