### PR TITLE
fix: add dark mode text color to main heading

### DIFF
--- a/src/components/shared/cards/cards.jsx
+++ b/src/components/shared/cards/cards.jsx
@@ -40,7 +40,7 @@ const Cards = ({ className, title, items, buttonType, textSize, cardSize }) => {
     <div className={classNames(className, 'bg-gray-4 dark:bg-gray-900')}>
       <Container>
         {title && (
-          <Heading className="mb-6 xs:text-center md:mb-10 lg:mb-14" tag="h2">
+          <Heading className="mb-6 xs:text-center md:mb-10 lg:mb-14 dark:text-white" tag="h2">
             {title}
           </Heading>
         )}


### PR DESCRIPTION
@paularah 
I noticed the main heading for Cards isn't visible in dark mode.
See https://cilium.io/get-involved/

so I Fixed it in this PR..
Can you approve it!