### PR TITLE
ui:  fix css for text visibility in dark mode

### DIFF
--- a/src/components/pages/adopters/logos/logos.jsx
+++ b/src/components/pages/adopters/logos/logos.jsx
@@ -104,7 +104,7 @@ const spaceXClassNames = {
 };
 
 const Logos = ({ title, items, spaceXSize, id }) => (
-  <section className="pt-10 md:pt-20 lg:pt-28 xl:pt-32" id={id}>
+  <section className="pt-10 md:pt-20 lg:pt-28 xl:pt-32 dark:text-white" id={id}>
     <Container size="md">
       <Link className="text-center" to={`#${id}`}>
         <Heading tag="h2">{title}</Heading>


### PR DESCRIPTION
Fixed a Text visibility in dark mode of adopters! 

Screenshot after fix
<img width="1898" height="927" alt="image" src="https://github.com/user-attachments/assets/f4184ecb-ab29-464d-ac63-91761de68876" />

