### PR TITLE
Improve UI of labs page banner in dark mode for better contrast and consistency

### DIFF
--- a/src/components/pages/labs/banner/banner.jsx
+++ b/src/components/pages/labs/banner/banner.jsx
@@ -4,8 +4,8 @@ import Button from 'components/shared/button';
 import Heading from 'components/shared/heading';
 
 const Banner = () => (
-  <div className="mt-10 flex w-full flex-col items-center justify-center space-y-6 rounded-xl bg-dark-blue px-10 py-14 md:mt-16 lg:mt-24 lg:flex-row lg:space-x-8 lg:space-y-0 lg:px-4 xl:mt-32 xl:space-x-14">
-    <Heading className="text-white" tag="h2" size="sm">
+  <div className="mt-10 flex w-full flex-col items-center justify-center space-y-6 rounded-xl bg-white dark:bg-gray-2 px-10 py-14 md:mt-16 lg:mt-24 lg:flex-row lg:space-x-8 lg:space-y-0 lg:px-4 xl:mt-32 xl:space-x-20 shadow-primary">
+    <Heading tag="h2" size="sm">
       Want to add your lab to the list? Submit a PR here
     </Heading>
     <Button


### PR DESCRIPTION
### Fixes #711 

This PR improves UI of the banner section on the labs page especially in the dark mode. It also ensures that the style of this banner remains consistent with other components on the website.

### Before 
<table>
<tr>
<td><strong>Light Mode</strong></td>
<td><strong>Dark Mode</strong></td>
</tr>
<tr>
<td>
<img width="1365" height="719" alt="Light Mode" src="https://github.com/user-attachments/assets/d9a4982b-98d1-4f3d-9cb5-cdd277518829" />
</td>
<td>
<img width="1365" height="715" alt="Dark Mode" src="https://github.com/user-attachments/assets/d8cefcc8-c185-4afb-8dbb-ca40727597d2" />
</td>
</tr>
</table>

### After
<table>
<tr>
<td><strong>Light Mode</strong></td>
<td><strong>Dark Mode</strong></td>
</tr>
<tr>
<td>
<img width="1365" height="716" alt="Screenshot 2025-08-10 194955" src="https://github.com/user-attachments/assets/33bb5ea2-1dfa-46b0-a033-28f4c6fceca6" />
</td>
<td>
<img width="1365" height="715" alt="Screenshot 2025-08-10 195314" src="https://github.com/user-attachments/assets/e05ae5dc-2dd6-4004-92d2-1e5bc475e7c1" />
</td>
</tr>
</table>

