### PR TITLE
feat: add dark theme to telling-story form page

### DIFF
--- a/src/components/pages/telling-story/hero/form/form.jsx
+++ b/src/components/pages/telling-story/hero/form/form.jsx
@@ -118,8 +118,10 @@ const Form = ({ formClassName }) => {
               name="message"
               {...register('message')}
             />
-            <div className="border-b border-gray-4 pb-4">
-              <span className="text-sm font-semibold">What do you need help with?</span>
+            <div className="border-b border-gray-4 dark:border-gray-7 pb-4">
+              <span className="text-sm font-semibold text-black dark:text-white">
+                What do you need help with?
+              </span>
               <div className="mt-5 grid gap-x-8 gap-y-4 md:grid-cols-[repeat(2,minmax(45%,max-content))]">
                 <Checkbox
                   id="reviewAbstract"

--- a/src/components/pages/telling-story/hero/hero.jsx
+++ b/src/components/pages/telling-story/hero/hero.jsx
@@ -14,15 +14,15 @@ const descriptionParagraphSecond =
   ' Not a native speaker and/or not confident about your writing skills? No worries. Bring the story and we’ll help you tell it in an engaging way.';
 
 const Hero = () => (
-  <section className="overflow-x-hidden bg-gray-4 py-10 pb-44 lg:pt-16">
+  <section className="overflow-x-hidden bg-gray-4 dark:bg-gray-900 py-10 pb-44 lg:pt-16">
     <Container className="grid grid-cols-12 gap-y-14 sm:gap-y-20 md:gap-y-24 lg:items-stretch lg:gap-y-0 lg:gap-x-8">
       <div className="col-span-full lg:col-span-5 lg:pt-10 xl:col-span-4">
-        <Heading size="lg" tag="h1">
+        <Heading size="lg" tag="h1" className="text-black dark:text-white">
           {title}
         </Heading>
 
-        <p className="text-md mt-5">{descriptionParagraphFirst}</p>
-        <p className="text-md mt-2.5">{descriptionParagraphSecond}</p>
+        <p className="text-md mt-5 dark:text-gray-2 text-black">{descriptionParagraphFirst}</p>
+        <p className="text-md mt-2.5 dark:text-gray-2 text-black">{descriptionParagraphSecond}</p>
       </div>
 
       <div className="relative col-span-full lg:col-span-7 xl:col-span-8">
@@ -42,7 +42,7 @@ const Hero = () => (
           alt=""
           aria-hidden
         />
-        <Form formClassName="relative rounded-xl bg-white w-full shadow-card p-4 md:p-8" />
+        <Form formClassName="relative rounded-xl bg-white dark:bg-[#0F1D3E] w-full shadow-card p-4 md:p-8" />
       </div>
     </Container>
   </section>

--- a/src/components/shared/checkbox/checkbox.jsx
+++ b/src/components/shared/checkbox/checkbox.jsx
@@ -8,14 +8,18 @@ const Checkbox = React.forwardRef((props, ref) => {
   return (
     <div className={classNames('checkbox', className)}>
       <input
-        className="checkbox__input"
+        className="checkbox__input bg-white dark:bg-[#A7B1BE]"
         type="checkbox"
         id={id}
         defaultChecked={defaultChecked}
         ref={ref}
         {...otherProps}
       />
-      <label className="checkbox__label" htmlFor={id}>
+      <label
+        className="checkbox__label dark:text-[#dfe5ed] text-black"
+        htmlFor={id}
+        aria-label={label}
+      >
         <span dangerouslySetInnerHTML={{ __html: label }} />
       </label>
     </div>

--- a/src/components/shared/field/field.jsx
+++ b/src/components/shared/field/field.jsx
@@ -10,13 +10,13 @@ export const FIELD_TAGS = {
 const Field = forwardRef(({ id, fieldName, className, tag: Tag, error, ...otherProps }, ref) => (
   <div className="relative flex w-full flex-col">
     {fieldName && (
-      <label htmlFor={id} className="text-sm font-semibold leading-none">
+      <label htmlFor={id} className="text-sm font-semibold leading-none text-black dark:text-white">
         {fieldName}
       </label>
     )}
     <Tag
       className={classNames(
-        'remove-autocomplete-styles w-full appearance-none rounded border border-gray-3 px-3 py-3 text-[16px] outline-none transition duration-200 hover:border-gray-2 focus:border-primary-1 xl:px-4 xl:py-5',
+        'remove-autocomplete-styles w-full appearance-none rounded border border-gray-3 px-3 py-3 text-[16px] outline-none hover:border-gray-2 focus:border-primary-1 xl:px-4 xl:py-5 bg-white dark:bg-[#0F1D3E] dark:text-white',
         className,
         {
           'border-additional-1 hover:border-additional-1 focus:border-additional-1': error,
@@ -29,6 +29,7 @@ const Field = forwardRef(({ id, fieldName, className, tag: Tag, error, ...otherP
       ref={ref}
       {...otherProps}
     />
+
     {error && (
       <span className="absolute top-[calc(100%+0.1rem)] text-xs text-additional-1">{error}</span>
     )}


### PR DESCRIPTION
This PR adds the dark theme to the /telling-story route

## Before 

<img width="1919" height="986" alt="Screenshot 2025-08-11 212422" src="https://github.com/user-attachments/assets/078bdc38-69fc-496b-98b5-3c856b464649" />

## After

<img width="1919" height="980" alt="image" src="https://github.com/user-attachments/assets/898de304-c1ad-4c63-8e98-63fef190101d" />
