### PR TITLE
Improve link background styles on newsletter cards

### DIFF
--- a/src/components/pages/newsletter/cards/cards.jsx
+++ b/src/components/pages/newsletter/cards/cards.jsx
@@ -87,7 +87,7 @@ const Cards = () => {
               {links.map(({ title, url, target }, index) => (
                 <Button
                   className="lg:text-base"
-                  theme={title === 'Explore Archive' ? 'primary-1' : 'outline-gray'}
+                  theme="primary-1"
                   size="md"
                   key={index}
                   to={url}


### PR DESCRIPTION
### Fixes #726 
This PR fixes the inconsistent link styles in the newsletter cards by unifying all card links to use the filled blue button style. This change improves visual consistency and creates a stronger call-to-action across all newsletter cards.

### Before changes :

<img width="1362" height="523" alt="Screenshot 2025-08-12 085002" src="https://github.com/user-attachments/assets/faf7506b-94be-4a39-bf71-1bbdbf4b51c7" />

### After changes :

<img width="1364" height="543" alt="Screenshot 2025-08-12 085440" src="https://github.com/user-attachments/assets/744e6241-1b52-437d-8eaf-f717a902ca6d" />
