### PR TITLE
feat: automated Lighthouse CI audits for pull requests

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -4,19 +4,28 @@ jobs:
   lhci:
     name: Lighthouse
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --max-old-space-size=8192
+      GATSBY_CONCURRENT_DOWNLOAD: 1
+
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Use Node.js 16.x
+
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
+
       - name: npm install, build
         run: |
           npm install
           npm run build
+
       - name: run Lighthouse CI
         run: |
           npm install -g @lhci/cli@0.15.x
           lhci autorun
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,31 +1,98 @@
-name: CI
-on: [push]
+name: CI - Lighthouse
+
+on:
+  pull_request:
+    branches:
+      - main
+
 jobs:
   lhci:
-    name: Lighthouse
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: --max-old-space-size=8192
       GATSBY_CONCURRENT_DOWNLOAD: 1
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Check for Lighthouse Trigger
+        id: trigger_check
+        run: |
+          if grep -q "Lighthouse Test" <<< "${{ github.event.pull_request.body }}"; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
+          fi
+
+
+      - name: Extract and build URLs from PR body paths
+        id: extract
+        if: steps.trigger_check.outputs.should_run == 'true'
+        shell: bash
+        env:
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+        run: |
+          echo "$PR_BODY" > pr_body.txt
+
+          # A more robust way to read each path and build the ARGS string
+          ARGS=""
+          while read -r path; do
+            # The -n flag ensures we only process non-empty lines
+            if [ -n "$path" ]; then
+              clean_path=$(echo "$path" | sed 's/[),.;:]*$//')
+              full_url="http://localhost:9000$clean_path"
+              ARGS="$ARGS --collect.url='$full_url'"
+            fi
+          done < <(grep -Eo '^/[a-zA-Z0-9/_.-]*$' pr_body.txt || true)
+          
+          # This part remains the same
+          if [ -z "$ARGS" ]; then
+            echo "has_urls=false" >> $GITHUB_OUTPUT
+            echo "has_localhost=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          echo "ARGS=$ARGS" >> $GITHUB_ENV
+          echo "has_urls=true" >> $GITHUB_OUTPUT
+          echo "has_localhost=true" >> $GITHUB_OUTPUT
+
+      - name: Checkout code
+        if: steps.trigger_check.outputs.should_run == 'true' && steps.extract.outputs.has_localhost == 'true'
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-
-      - name: npm install, build
+      - name: Install dependencies & build
+        if: steps.trigger_check.outputs.should_run == 'true' && steps.extract.outputs.has_localhost == 'true'
         run: |
-          npm install
+          rm -rf .cache public
+          npm ci
           npm run build
 
-      - name: run Lighthouse CI
+      - name: Start static server
+        if: steps.trigger_check.outputs.should_run == 'true' && steps.extract.outputs.has_localhost == 'true'
+        shell: bash
         run: |
-          npm install -g @lhci/cli@0.15.x
-          lhci autorun
+          npx http-server ./public -p 9000 --silent &
+          TIMEOUT=60
+          COUNT=0
+          until curl -sSf http://localhost:9000/ >/dev/null; do
+            sleep 1
+            COUNT=$((COUNT+1))
+            if [ $COUNT -ge $TIMEOUT ]; then
+              echo "Server did not start within timeout"
+              exit 1
+            fi
+          done
+          echo "Local server ready"
+
+      - name: Run Lighthouse CI for supplied URLs
+        if: steps.trigger_check.outputs.should_run == 'true' && steps.extract.outputs.has_urls == 'true'
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+        run: |
+          npm install -g @lhci/cli@0.15.x
+          if [ -z "${ARGS}" ]; then
+            echo "No URLs provided. Skipping LHCI."
+            exit 0
+          fi
+          echo "Running LHCI autorun with URLs: $ARGS"
+          lhci autorun $ARGS

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,0 +1,22 @@
+name: CI
+on: [push]
+jobs:
+  lhci:
+    name: Lighthouse
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - name: npm install, build
+        run: |
+          npm install
+          npm run build
+      - name: run Lighthouse CI
+        run: |
+          npm install -g @lhci/cli@0.15.x
+          lhci autorun

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -242,7 +242,7 @@ const plugins = [
   {
     resolve: 'gatsby-plugin-canonical-urls',
     options: {
-      siteUrl: process.env.GATSBY_DEFAULT_SITE_URL,
+      siteUrl: process.env.GATSBY_DEFAULT_SITE_URL || 'https://cilium.io',
     },
   },
   {
@@ -281,7 +281,7 @@ module.exports = {
     // pathPrefix: "",
     siteImage: '/images/social-preview.jpg',
     siteLanguage: 'en',
-    siteUrl: process.env.GATSBY_DEFAULT_SITE_URL,
+    siteUrl: process.env.GATSBY_DEFAULT_SITE_URL || 'https://cilium.io',
     /* author */
     authorName: 'cilium',
     authorTwitterAccount: '@ciliumproject',

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,0 +1,32 @@
+module.exports = {
+  ci: {
+    collect: {
+      staticDistDir: './public',
+      url: [
+        'http://localhost:9000/',
+        'http://localhost:9000/adopters/',
+        'http://localhost:9000/blog/',
+        'http://localhost:9000/#networking/',
+        'http://localhost:9000/get-involved/',
+      ],
+      numberOfRuns: 1,
+      settings: {
+        emulatedFormFactor: 'website',
+        throttlingMethod: 'simulate',
+      },
+    },
+
+    assert: {
+      assertions: {
+        'categories:performance': ['warn', { minScore: 0.7 }],
+        'categories:accessibility': ['warn', { minScore: 0.9 }],
+        'categories:best-practices': ['warn', { minScore: 0.9 }],
+        'categories:seo': ['warn', { minScore: 0.9 }],
+      },
+    },
+
+    upload: {
+      target: 'temporary-public-storage',
+    },
+  },
+};

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -2,16 +2,9 @@ module.exports = {
   ci: {
     collect: {
       staticDistDir: './public',
-      url: [
-        'http://localhost:9000/',
-        'http://localhost:9000/adopters/',
-        'http://localhost:9000/blog/',
-        'http://localhost:9000/#networking/',
-        'http://localhost:9000/get-involved/',
-      ],
       numberOfRuns: 1,
       settings: {
-        emulatedFormFactor: 'website',
+        emulatedFormFactor: 'Desktop',
         throttlingMethod: 'simulate',
       },
     },


### PR DESCRIPTION
### Summary of Changes

This pull request introduces a new, automated **Lighthouse CI** workflow that runs on every pull request. The workflow helps contributors and reviewers monitor **website performance, accessibility, SEO, and best practices** on a per-page basis, preventing performance regressions before merging into the main codebase.

The workflow is configurable ( it will only run when explicitly requested pages with trigger word)

---

### How to Use This Feature

To trigger a Lighthouse CI audit:

1. Add the phrase **`Lighthouse Test`** to your PR body.
2. Include a list of the pages you want to audit, each on a separate line.

**Example PR Body:**


```
This PR updates the adopters and blog pages.

Lighthouse Test
/
/adopters/
/blog/
/get-involved/
```


---

### Workflow Behavior

- If **`Lighthouse Test`** is present in the PR body:
  - Runs a **full Gatsby build** once.
  - Starts a **local static server**.
  - Runs Lighthouse audits **only on the specified paths**.
  - Generates a detailed Lighthouse report with a link provided in the workflow logs.

- If **`Lighthouse Test`** is **not** present:
  - Lighthouse-specific steps are skipped.
  - Workflow completes very quickly (5-6 seconds)

---

closes [#716](https://github.com/cilium/cilium.io/issues/716) 
