### PR TITLE
Fix: Home page Hero Flicker on Page Reload

### DIFF
--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -1,10 +1,9 @@
+import { StaticImage } from 'gatsby-plugin-image';
 import React from 'react';
 
 import Button from 'components/shared/button';
 import Container from 'components/shared/container';
 import Heading from 'components/shared/heading';
-
-import illustration from './images/hero-illustration.svg';
 
 const title = 'eBPF-based Networking, Observability, Security';
 const description =
@@ -14,12 +13,7 @@ const Hero = () => (
   <section className="overflow-hidden bg-gray-4 dark:bg-gray-900 pt-5 pb-0 md:pt-16 md:pb-20 lg:pt-28 lg:pb-36">
     <Container className="grid grid-cols-12 md:gap-x-8">
       <div className="relative z-10 col-span-full lg:col-span-6 2xl:col-span-7">
-        <Heading
-          className="font-semibold dark:text-[#579dd6] text-black leading-tight lg:max-w-2xl lg:leading-tight"
-          tag="h1"
-          size="lg"
-          asHTML
-        >
+        <Heading className="dark:text-[#579dd6]" tag="h1" size="lg" asHTML>
           {title}
         </Heading>
         <div
@@ -40,9 +34,9 @@ const Hero = () => (
         </div>
       </div>
       <div className="relative col-span-full mt-5 flex justify-center lg:col-span-6 lg:mt-0 2xl:col-span-5 2xl:-ml-8">
-        <img
+        <StaticImage
           className="top-0 h-full w-full max-w-[512px] lg:absolute lg:-right-16 lg:h-auto lg:w-[580px] lg:max-w-max xl:-top-[74px] xl:-right-16 xl:w-max"
-          src={illustration}
+          src="./images/hero-illustration.svg" // StaticImage doesn't support dynamic imports
           alt={title}
           loading="eager"
           width={761}


### PR DESCRIPTION
## Description

This pull request resolves the heading and image flicker issue on the homepage in dark mode.

## Changes Introduced

- Removed unnecessary className styling from the header to prevent flickering on load.

- Replaced <img> with StaticImage because it provides Lazy Loading by Default and Blur-up Placeholders.


## Demo
> 

https://github.com/user-attachments/assets/c6da5ca5-b4b7-4e91-be53-f5bfdaef356e


