### PR TITLE
Fix: Ensure consistent image size and background in event page 

### DIFF
--- a/src/components/pages/events/events-board/event-card/event-card.jsx
+++ b/src/components/pages/events/events-board/event-card/event-card.jsx
@@ -18,9 +18,9 @@ const EventCover = ({ ogImage, title }) => {
 
   return ogImage ? (
     <GatsbyImage
-      className="h-[261px] rounded-t-lg lg:h-[180px] sm:h-[221px]"
+      className="h-[261px] rounded-t-lg lg:h-[180px] sm:h-[221px] bg-white"
       image={getImage(ogImage)}
-      objectFit="cover"
+      objectFit="contain"
       alt={title}
       loading="lazy"
     />


### PR DESCRIPTION
## Description

This pull request updates the GatsbyImage component styles to ensure consistent backgrounds in dark mode.

## Changes Introduced

- Added bg-white to the GatsbyImage component so that transparent areas always appear on a clean white background.

- Maintained objectFit="contain" to avoid zoomed/cropped images.

## Demo
> 


https://github.com/user-attachments/assets/bcc35f9c-1fc8-432a-a9ac-e1b1db945c50



