### PR TITLE
Fix : Ensure text in images remains visible across themes

### DIFF
--- a/src/components/pages/industries/bullet-section/bullet-section.jsx
+++ b/src/components/pages/industries/bullet-section/bullet-section.jsx
@@ -43,7 +43,10 @@ const BulletSection = ({
           )}
         >
           <img
-            className={classNames('max-h-full w-full lg:max-h-[350px]', imageStyle)}
+            className={classNames(
+              'max-h-full w-full lg:max-h-[350px] bg-white rounded-lg',
+              imageStyle
+            )}
             width={592}
             height={350}
             src={imageSrc}


### PR DESCRIPTION
### Description

Currently, the text inside some images is not clearly visible in dark mode.
This PR adds a white background behind images to ensure the text remains readable across themes.

---

### Observed Issues



<table> <tr> <td><strong>Before</strong></td> <td><strong>After</strong></td> </tr> <tr> <td> <img width="1920" height="1080" alt="250817_08h03m42s_screenshot" src="https://github.com/user-attachments/assets/5087f7be-4887-4a46-ae83-3ca1e3e754d6" /> </td> <td> <img width="1920" height="1080" alt="250817_08h06m59s_screenshot" src="https://github.com/user-attachments/assets/307f6700-ceff-4662-b0c7-911b91ff9fca" /> </td> </tr> <tr> <td> 
<img width="1920" height="1080" alt="250817_08h03m31s_screenshot" src="https://github.com/user-attachments/assets/acfb0d4c-907a-4e96-a8af-99ec5e76a16c" /></td> <td> <img width="1920" height="1080" alt="250817_08h07m18s_screenshot" src="https://github.com/user-attachments/assets/f3751f82-9ef1-4691-8a52-39041511b5d4" /> </td> </tr> </table>