### PR TITLE
Fix: Adjust hero illustration size

### DIFF
--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -35,7 +35,7 @@ const Hero = () => (
       </div>
       <div className=" flex justify-center col-span-full lg:col-span-6 2xl:col-span-5 mt-8 lg:mt-0 lg:block">
         <StaticImage
-          className="w-full max-w-[650px] h-auto mx-auto xl:max-w-[750px] xl:w-[750px]"
+          className="w-full max-w-[600px] h-auto mx-auto xl:max-w-[700px] xl:w-[700px]"
           src="./images/hero-illustration.svg" // StaticImage doesn't support dynamic imports
           alt={title}
           loading="eager"

--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -1,17 +1,18 @@
-import { StaticImage } from 'gatsby-plugin-image';
 import React from 'react';
 
 import Button from 'components/shared/button';
 import Container from 'components/shared/container';
 import Heading from 'components/shared/heading';
 
+import illustration from './images/hero-illustration.svg';
+
 const title = 'eBPF-based Networking, Observability, Security';
 const description =
   'Cilium is an open source, cloud native solution for providing, securing, and observing network connectivity between workloads, fueled by the revolutionary Kernel technology eBPF';
 
 const Hero = () => (
-  <section className="relative overflow-hidden bg-gray-4 dark:bg-gray-900 pt-5 pb-0 md:pt-8 md:pb-10 lg:pt-10 lg:pb-14">
-    <Container className="grid grid-cols-12 md:gap-x-8 items-center">
+  <section className="overflow-hidden bg-gray-4 dark:bg-gray-900 pt-5 pb-0 md:pt-16 md:pb-20 lg:pt-28 lg:pb-36">
+    <Container className="grid grid-cols-12 md:gap-x-8">
       <div className="relative z-10 col-span-full lg:col-span-6 2xl:col-span-7">
         <Heading className="dark:text-[#579dd6]" tag="h1" size="lg" asHTML>
           {title}
@@ -33,13 +34,14 @@ const Hero = () => (
           </Button>
         </div>
       </div>
-      <div className=" flex justify-center col-span-full lg:col-span-6 2xl:col-span-5 mt-8 lg:mt-0 lg:block">
-        <StaticImage
-          className="w-full max-w-[600px] h-auto mx-auto xl:max-w-[700px] xl:w-[700px]"
-          src="./images/hero-illustration.svg" // StaticImage doesn't support dynamic imports
+      <div className="relative col-span-full mt-5 flex justify-center lg:col-span-6 lg:mt-0 2xl:col-span-5 2xl:-ml-8">
+        <img
+          className="top-0 h-full w-full max-w-[512px] lg:absolute lg:-right-16 lg:h-auto lg:w-[580px] lg:max-w-max xl:-top-[74px] xl:-right-16 xl:w-max"
+          src={illustration}
           alt={title}
           loading="eager"
-          placeholder="blurred"
+          width={761}
+          height={555}
         />
       </div>
     </Container>

--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -10,8 +10,8 @@ const description =
   'Cilium is an open source, cloud native solution for providing, securing, and observing network connectivity between workloads, fueled by the revolutionary Kernel technology eBPF';
 
 const Hero = () => (
-  <section className="overflow-hidden bg-gray-4 dark:bg-gray-900 pt-5 pb-0 md:pt-16 md:pb-20 lg:pt-28 lg:pb-36">
-    <Container className="grid grid-cols-12 md:gap-x-8">
+  <section className="relative overflow-hidden bg-gray-4 dark:bg-gray-900 pt-5 pb-0 md:pt-8 md:pb-10 lg:pt-10 lg:pb-14">
+    <Container className="grid grid-cols-12 md:gap-x-8 items-center">
       <div className="relative z-10 col-span-full lg:col-span-6 2xl:col-span-7">
         <Heading className="dark:text-[#579dd6]" tag="h1" size="lg" asHTML>
           {title}
@@ -33,14 +33,13 @@ const Hero = () => (
           </Button>
         </div>
       </div>
-      <div className="relative col-span-full mt-5 flex justify-center lg:col-span-6 lg:mt-0 2xl:col-span-5 2xl:-ml-8">
+      <div className="col-span-full lg:col-span-6 2xl:col-span-5 mt-8 lg:mt-0">
         <StaticImage
-          className="top-0 h-full w-full max-w-[512px] lg:absolute lg:-right-16 lg:h-auto lg:w-[580px] lg:max-w-max xl:-top-[74px] xl:-right-16 xl:w-max"
+          className="w-full max-w-[650px] h-auto mx-auto xl:max-w-[750px] xl:w-[750px]"
           src="./images/hero-illustration.svg" // StaticImage doesn't support dynamic imports
           alt={title}
           loading="eager"
-          width={761}
-          height={555}
+          placeholder="blurred"
         />
       </div>
     </Container>

--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -33,7 +33,7 @@ const Hero = () => (
           </Button>
         </div>
       </div>
-      <div className="col-span-full lg:col-span-6 2xl:col-span-5 mt-8 lg:mt-0">
+      <div className=" flex justify-center col-span-full lg:col-span-6 2xl:col-span-5 mt-8 lg:mt-0 lg:block">
         <StaticImage
           className="w-full max-w-[650px] h-auto mx-auto xl:max-w-[750px] xl:w-[750px]"
           src="./images/hero-illustration.svg" // StaticImage doesn't support dynamic imports


### PR DESCRIPTION
### Description

- This PR fixes the layout of the hero illustration on large screens. The issue arose after the image was migrated from a standard <img> tag to the StaticImage .
- The previous styling worked correctly with the `<img>` tag, but the new component introduced layout shifts and sizing issues. 

--- 
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/85924230-01ce-445c-9a23-7cbe30629525" width="400"/></td>
    <td><img src="https://github.com/user-attachments/assets/e2fad2ea-ff2d-4bb2-8b46-3013e5dd51d7" width="400"/></td>
  </tr>
</table>

