### PR TITLE
fix: remove dead link to Solo training

### DIFF
--- a/src/components/pages/enterprise/training/training.jsx
+++ b/src/components/pages/enterprise/training/training.jsx
@@ -59,16 +59,6 @@ const items = [
     buttonLink: 'https://training.linuxfoundation.org/training/introduction-to-cilium-lfs146x/',
     buttonTarget: '_blank',
   },
-  {
-    logoName: 'soloio',
-    title: 'Introduction to Cilium',
-    description:
-      'In this workshop, you will learn the essential skills to deploy the Cilium CNI on a test Kubernetes cluster, gather metrics, and enforce network policies.',
-    buttonText: 'Get Started',
-    buttonLink:
-      'https://academy.solo.io/introduction-to-cilium-with-fundamentals-for-cilium-certification',
-    buttonTarget: '_blank',
-  },
 ];
 
 const promo = {


### PR DESCRIPTION
I searched through the academy and couldn't find any courses related to Cilium and the current link doesn't work. Happy to leave this open for a few weeks if someone can come along and correct me.