### PR TITLE
chore: add github actions workflow for automatic pr labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,33 @@
+bug:
+  - 'src/**/*.js'
+  - 'src/**/*.jsx'
+  - 'src/**/*.ts'
+  - 'src/**/*.tsx'
+
+feature:
+  - 'src/components/**'
+  - 'src/pages/**'
+  - 'src/templates/**'
+  - 'src/hooks/**'
+
+docs:
+  - 'docs/**'
+  - 'README.md'
+  - 'CONTRIBUTING.md'
+  - 'src/posts/**'
+
+chore:
+  - 'package.json'
+  - 'package-lock.json'
+  - 'Makefile'
+  - '.github/**'
+  - 'gatsby-config.js'
+  - 'gatsby-node.js'
+  - 'gatsby-browser.js'
+  - 'gatsby-ssr.js'
+  - 'Dockerfile'
+
+# Images or media updates
+images:
+  - 'src/images/**'
+  - 'static/**'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,23 @@
+name: 'PR Labeler'
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Apply PR labels based on files
+        uses: actions/labeler@v3
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Add "needs-review" label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: needs-review


### PR DESCRIPTION
fix: #775 

### Description:
- This PR adds a GitHub Actions workflow to automatically label pull requests based on the files changed. It also adds a needs-review label to all new or updated PRs.

### Benefits:
- Automatically categorizes PRs as bug, feature, docs, chore, or images based on changed files.
- Ensures maintainers can quickly identify the type of contribution.
- Adds needs-review to every PR, highlighting PRs ready for review.
- Reduces manual labeling and improves workflow efficiency for contributors.
- `GITHUB_TOKEN` is provided automatically, no extra secrets needed.
