### PR TITLE
feat(seo): add metadata for /get-started page (#681)

### DIFF
--- a/src/pages/industries/ai.jsx
+++ b/src/pages/industries/ai.jsx
@@ -186,7 +186,8 @@ export default MediaEntertainmentPage;
 export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
-    description: 'Discover Cloud Providers use Cilium',
+    description:
+      'Discover how Cilium powers AI/ML workloads with fast networking, robust security, and observability for Kubernetes.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/pages/industries/cloud-providers.jsx
+++ b/src/pages/industries/cloud-providers.jsx
@@ -215,7 +215,8 @@ export default MediaEntertainmentPage;
 export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
-    description: 'Discover Cloud Providers use Cilium',
+    description:
+      'See why top cloud providers like Google, AWS, Azure, and Alibaba trust Cilium for secure, scalable, and observable Kubernetes networking.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/pages/industries/consulting.jsx
+++ b/src/pages/industries/consulting.jsx
@@ -103,7 +103,8 @@ const consultingResources = [
     title: 'Reducing Kubernetes tool sprawl: Tietoevry uses Cilium and Hubble',
     description:
       'Tietroevry Industries reduced Kubernetes tool sprawl using Cilium, greatly simplifying its overall Kubernetes administration.',
-    buttonLink: 'https://isovalent.com/blog/post/kubernetes-tool-sprawl/?utm_source=website-cilium&utm_medium=referral&utm_campaign=cilium-blog',
+    buttonLink:
+      'https://isovalent.com/blog/post/kubernetes-tool-sprawl/?utm_source=website-cilium&utm_medium=referral&utm_campaign=cilium-blog',
     imageSrc: TieToevryOfficeImage,
     imageAlt: 'tieotvry office building',
     buttonText: 'Watch the Talk',
@@ -143,7 +144,7 @@ export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
     description:
-      'Discover how consulting companies leverage Cilium to deliver solutions for a wide range of clients',
+      'World-leading consulting companies are now turning to Cilium, leveraging its capabilities to deliver secure, high-performance, and observable cloud native solutions to clients ranging from startups, nationwide banks, and large enterprises.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/pages/industries/consulting.jsx
+++ b/src/pages/industries/consulting.jsx
@@ -144,7 +144,7 @@ export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
     description:
-      'World-leading consulting companies are now turning to Cilium, leveraging its capabilities to deliver secure, high-performance, and observable cloud native solutions to clients ranging from startups, nationwide banks, and large enterprises.',
+      'World-leading consulting companies use Cilium, leveraging its capabilities to deliver secure, high-performance, and observable cloud native solutions to clients ranging from startups, nationwide banks, and large enterprises.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/pages/industries/e-commerce.jsx
+++ b/src/pages/industries/e-commerce.jsx
@@ -238,7 +238,7 @@ export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
     description:
-      'E-commerce teams scale globally and deliver better user experiences with Cilium's eBPF-optimized data plane.',
+      'E-commerce teams scale globally and deliver better user experiences with Cilium eBPF-optimized data plane.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/pages/industries/e-commerce.jsx
+++ b/src/pages/industries/e-commerce.jsx
@@ -238,7 +238,7 @@ export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
     description:
-      'Discover how global e-commerce brands leverage Cilium to build globally distributed services and gain the edge in speed, security and observability',
+      'E-commerce teams can scale globally and deliver better user experiences through a low-latency network path from Cilium eBPF-optimized data plane.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/pages/industries/e-commerce.jsx
+++ b/src/pages/industries/e-commerce.jsx
@@ -238,7 +238,7 @@ export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
     description:
-      'E-commerce teams can scale globally and deliver better user experiences through a low-latency network path from Cilium eBPF-optimized data plane.',
+      'E-commerce teams scale globally and deliver better user experiences with Cilium's eBPF-optimized data plane.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/pages/industries/edge-computing.jsx
+++ b/src/pages/industries/edge-computing.jsx
@@ -120,7 +120,7 @@ export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
     description:
-      'How Cilium enables secure, high-performance, and observable networking for edge computing across distributed and resource-constrained environments.',
+      'Cilium delivers efficient, secure networking for edge computing deployments across distributed locations with limited resources.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/pages/industries/edge-computing.jsx
+++ b/src/pages/industries/edge-computing.jsx
@@ -119,7 +119,8 @@ export default EdgeComputingPage;
 export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
-    description: 'Discover Cloud Providers use Cilium',
+    description:
+      'How Cilium enables secure, high-performance, and observable networking for edge computing across distributed and resource-constrained environments.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/pages/industries/financial-services.jsx
+++ b/src/pages/industries/financial-services.jsx
@@ -271,7 +271,7 @@ export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
     description:
-      'With Cilium, companies in the financial services industry can achieve improved observability, maintain security controls, and weave compliance and security governance for Kubernetes environments directly into the DevOps process.',
+      'Financial services use Cilium to strengthen security, improve observability, and integrate compliance governance directly into DevOps workflows.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/pages/industries/financial-services.jsx
+++ b/src/pages/industries/financial-services.jsx
@@ -271,7 +271,7 @@ export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
     description:
-      'Discover how companies in the financial service industry leverage cilium for zero-trust security and continuos compliance',
+      'With Cilium, companies in the financial services industry can achieve improved observability, maintain security controls, and weave compliance and security governance for Kubernetes environments directly into the DevOps process.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/pages/industries/media-entertainment.jsx
+++ b/src/pages/industries/media-entertainment.jsx
@@ -176,7 +176,7 @@ export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
     description:
-      'Leverage the Cilium advantage to deliver seamless experiences to your users, reduce operational complexity for your teams, and secure your environments.',
+      'Cilium powers media streaming platforms with high-performance load balancing, low-latency content delivery, and security for global audiences at scale.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/pages/industries/media-entertainment.jsx
+++ b/src/pages/industries/media-entertainment.jsx
@@ -176,7 +176,7 @@ export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
     description:
-      'Discover how companies in the media and entertainment industry leverage cilium for robust security, scalability, and flexibility at a reduced operational overhead',
+      'Leverage the Cilium advantage to deliver seamless experiences to your users, reduce operational complexity for your teams, and secure your environments.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/pages/industries/security.jsx
+++ b/src/pages/industries/security.jsx
@@ -211,7 +211,7 @@ export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
     description:
-      'Cilium secures cloud-native applications with identity-based policies, runtime enforcement, and transparent encryption, built for modern security challenges.',
+      'Cilium secures cloud native applications with identity-based policies, runtime enforcement, and transparent encryption, built for modern security challenges.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/pages/industries/security.jsx
+++ b/src/pages/industries/security.jsx
@@ -211,7 +211,7 @@ export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
     description:
-      'Cilium delivers robust cloud native security with features like transparent encryption, mutual authentication, security observability, advanced network polices, egress gateway, and runtime enforcement.',
+      'Cilium secures cloud-native applications with identity-based policies, runtime enforcement, and transparent encryption, built for modern security challenges.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/pages/industries/security.jsx
+++ b/src/pages/industries/security.jsx
@@ -211,7 +211,7 @@ export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
     description:
-      'Discover how companies in the security industry and companies whom security is integral to their operations leverage cilium.',
+      'Cilium delivers robust cloud native security with features like transparent encryption, mutual authentication, security observability, advanced network polices, egress gateway, and runtime enforcement.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/pages/industries/software.jsx
+++ b/src/pages/industries/software.jsx
@@ -198,7 +198,7 @@ export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
     description:
-      'Discover how SaaS, software, and DBaaS companies leverage cilium to meet the challenges of modern software deployment head-on.',
+      'With Cilium, SaaS, software, and DBaaS teams can establish infrastructure capable of scaling their products globally to reach customers wherever they may be.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/pages/industries/telcos-datacenters.jsx
+++ b/src/pages/industries/telcos-datacenters.jsx
@@ -168,7 +168,7 @@ export const Head = ({ location: { pathname } }) => {
   const pageMetadata = {
     title: heroContent.heading,
     description:
-      'Simplify your Telco and data center networks, comply with regulatory requirements, and ease your cloud native journey with Cilium.',
+      'Cilium provides a comprehensive suite of capabilities that empower telcos and data center providers to transition seamlessly from traditional infrastructure to cloud native environments.',
     slug: pathname,
   };
   return <SEO data={pageMetadata} />;

--- a/src/utils/seo-metadata.js
+++ b/src/utils/seo-metadata.js
@@ -8,9 +8,9 @@ const homepage = {
   description: 'Cilium provides eBPF-based networking, observability, and security for Kubernetes and beyond. Trusted by all major cloud providers and cloud native platforms worldwide.',
 };
 const learn = {
-  title: 'Cilium - What is Cilium?',
+  title: 'Cilium - Get Started with Cilium',
   description:
-    'Cilium is an open source project to provide networking, security, and observability for cloud native environments such as Kubernetes clusters and other container orchestration platforms.',
+    'Learn how to get started with Cilium, from installation to advanced use cases and features through tutorials, documentation, and videos',
 };
 const adopters = {
   title: 'Cilium users and real world case studies',

--- a/src/utils/seo-metadata.js
+++ b/src/utils/seo-metadata.js
@@ -8,9 +8,9 @@ const homepage = {
   description: 'Cilium provides eBPF-based networking, observability, and security for Kubernetes and beyond. Trusted by all major cloud providers and cloud native platforms worldwide.',
 };
 const learn = {
-  title: 'Cilium - Get Started with Cilium',
+  title: 'Cilium - What is Cilium?',
   description:
-    'Learn how to get started with Cilium, from installation to advanced use cases and features through tutorials, documentation, and videos',
+    'Cilium is an open source project to provide networking, security, and observability for cloud native environments such as Kubernetes clusters and other container orchestration platforms.',
 };
 const adopters = {
   title: 'Cilium users and real world case studies',


### PR DESCRIPTION
Fixes #681
### fix: improve SEO descriptions for industries pages

### Summary
This PR introduces a clean-up fix for the SEO metadata across the industries pages, improving consistency and optimization. The updated descriptions are concise, SEO-friendly, and better capture the essence of each page.

### Context
The existing descriptions for the industries pages were overly generic. I refined them to be more specific, highlight unique value propositions, and improve SEO performance.

Other sections like /blog, /blog-post, /events, and /labs already handle metadata dynamically through the shared component, so no changes were needed there.

### Changes

Clean-up fix for meta descriptions in industries pages:

/consulting

/e-commerce

/financial-services

/media-entertainment

/security

/software

/telcos-datacenters

Ensured the new descriptions are concise, relevant, and SEO-friendly.