### PR TITLE
docs: add guidance for laptops without fans to reduce Gatsby resource usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ npm run start
 > ```
 >
 > This allows Node.js to use up to 8 GB of RAM. You can adjust the number (`8192`) if needed based on your system capacity.
+>
+> **Tip for laptops without fans** (e.g., MacBook Air):  
+> To reduce heat and memory usage during development, you can limit Gatsby to fewer CPU cores:
+>
+> ```bash
+> GATSBY_CPU_COUNT=2 npm run develop
+> ```
 
 ### Build the website
 


### PR DESCRIPTION
### Summary
- While contributing to the Cilium website using my MacBook Air M2, I noticed the laptop would heat up significantly during builds and while running npm run develop. Since the MacBook Air has no fan, this quickly became an issue.

- After experimenting, I realized that limiting Gatsby to fewer CPU cores (GATSBY_CPU_COUNT=2 npm run develop) greatly reduced both heat and memory usage, making development much smoother.

- Changes
	- Updated the README troubleshooting section.
	- Added guidance for laptops without fans (e.g., MacBook Air) on using GATSBY_CPU_COUNT=2 npm run develop.

### Why
- This will help contributors who use lightweight, fanless laptops avoid overheating and resource issues when working with the site.