### PR TITLE
fix: Make external URL for external blog post work

### DIFF
--- a/src/posts/2025-10-07-Cilium-Network-Policies-from-first-principles-to-production/index.md
+++ b/src/posts/2025-10-07-Cilium-Network-Policies-from-first-principles-to-production/index.md
@@ -6,7 +6,7 @@ ogSummary: 'Gain a deeper understanding how to construct and deploy Cilium Netwo
 categories:
   - Community
   - How-To
-externalUrl: 'https://https://veducate.co.uk/cilium-network-policies-from-first-principles-to-production/'
+externalUrl: 'https://veducate.co.uk/cilium-network-policies-from-first-principles-to-production/'
 tags:
   - Cilium
 ---


### PR DESCRIPTION
The link on https://cilium.io/blog/ appears to be broken because of the duplicate https:///