### PR TITLE
Docs/clarify run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Explore the [Development Commands](#development-commands) section for more avail
 ### Run the website
 
 ```bash
+npm install
 npm run start
 ```
 


### PR DESCRIPTION
This PR updates the README to clarify the recommended command for running the site locally.

It aligns the "Run the website" section with the Makefile-based workflow by recommending `make start`, which helps avoid confusion for new contributors. No functional or behavioral changes are included.

Fixes #862 