### PR TITLE
ci: update Drone CI to use Node.js 18 LTS

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,7 @@ name: default
 
 steps:
   - name: tests
-    image: node:12.14.0-alpine3.11
+    image: node:18-alpine
     environment:
       GATSBY_DEFAULT_SITE_URL: http://localhost
     commands:


### PR DESCRIPTION
This PR updates the Drone CI image from Node 12 (EOL) to Node.js 18 LTS.

- Aligns CI with the Node version specified in DEPENDENCY_UPDATES.md
- Removes use of an unsupported and insecure Node version
- No changes to CI logic, steps, or pipeline structure

Closes #<issue-number>

Fixes #868 