### PR TITLE
fix : images in dark mode

### DIFF
--- a/src/pages/industries/consulting.jsx
+++ b/src/pages/industries/consulting.jsx
@@ -59,6 +59,7 @@ const bulletSection1 = {
   ],
   imageSrc: ConsultingImage1,
   imageAlt: 'cilium mesh architecture illustration',
+  imageStyle:"bg-white p-2 rounded-lg"
 };
 
 const bulletSection2 = {

--- a/src/pages/industries/financial-services.jsx
+++ b/src/pages/industries/financial-services.jsx
@@ -98,6 +98,7 @@ const bulletSection1 = {
   imageSrc: FinanceImage3,
   imageAlt: 'cilium TLS keys and certificate illustration',
   imageRight: false,
+  imageStyle:"bg-white p-2 rounded-lg"
 };
 
 const bulletSection3 = {

--- a/src/pages/industries/telcos-datacenters.jsx
+++ b/src/pages/industries/telcos-datacenters.jsx
@@ -68,6 +68,7 @@ const bulletSection3 = {
   ],
   imageSrc: TelcoImage3,
   imageAlt: 'cilium SRv6',
+  imageStyle:"bg-white p-2 rounded-lg"
 };
 
 const telcoTalks = [

--- a/src/pages/outcomes/network-automation.jsx
+++ b/src/pages/outcomes/network-automation.jsx
@@ -98,6 +98,7 @@ const sectionContent2 = {
   imageHeight: 431,
   imageAlt: 'identities with cilium',
   imageRight: true,
+  imageStyle:"bg-white p-2 rounded-lg"
 };
 
 const sectionContent3 = {

--- a/src/pages/outcomes/zero-trust.jsx
+++ b/src/pages/outcomes/zero-trust.jsx
@@ -66,6 +66,7 @@ const sectionContent1 = {
   ],
   imageSrc: ZeroTrustImage1,
   imageAlt: 'cilium TLS keys and certificate illustration',
+  imageStyle:"bg-white p-2 rounded-lg"
 };
 
 const sectionContent2 = {
@@ -79,6 +80,7 @@ const sectionContent2 = {
   imageHeight: 431,
   imageAlt: 'identities with cilium',
   imageRight: true,
+  imageStyle:"bg-white p-2 rounded-lg"
 };
 
 const sectionContent3 = {


### PR DESCRIPTION
- Description 
Earlier some images were not properly visible in dark mode 

- Fixes : #876 

- Screenshots
<img width="548" height="309" alt="Screenshot 2026-01-29 173916" src="https://github.com/user-attachments/assets/6372afd6-ba63-4dcd-b8b8-66f862c5a8f9" />
<img width="525" height="225" alt="Screenshot 2026-01-29 173923" src="https://github.com/user-attachments/assets/c56bdbba-b7ad-427d-b04a-19e9d21f780f" />
<img width="518" height="351" alt="Screenshot 2026-01-29 174011" src="https://github.com/user-attachments/assets/eb3a38c3-0dbe-40c3-91da-353d4c133792" />
<img width="481" height="156" alt="Screenshot 2026-01-29 174207" src="https://github.com/user-attachments/assets/4f64f96a-9dc1-45dc-a815-1899c29e0ce1" />

- Reference links : 
https://cilium.io/outcomes/zero-trust/
https://cilium.io/outcomes/network-automation/
https://cilium.io/industries/consulting/
https://cilium.io/industries/financial-services/
https://cilium.io/industries/telcos-datacenters/
