### PR TITLE
fix : dark mode ui bugs

### DIFF
--- a/src/components/pages/events/cta-section/cta-section.jsx
+++ b/src/components/pages/events/cta-section/cta-section.jsx
@@ -14,7 +14,7 @@ const form = {
 const CtaSection = () => (
   <section className="pt-10 pb-16 text-center border-b border-gray-3 md:pt-14 md:pb-20 lg:pt-16 lg:pb-28">
     <Container>
-      <Heading tag="h2" className="pb-8 lg:pb-12">
+      <Heading tag="h2" className="pb-8 text-gray-900 dark:text-white lg:pb-12">
         {title}
       </Heading>
       <div className="grid grid-cols-2 gap-y-8 lg:gap-y-0 lg:gap-x-6 xl:gap-x-8">


### PR DESCRIPTION
- Fixes #875 

 This PR adds css styling to make sure the text is visible in dark mode also.
 
 - Screenshots 

Before : 
<img width="981" height="422" alt="Screenshot 2026-01-29 193533" src="https://github.com/user-attachments/assets/ad42a2cc-dca6-4814-8982-a60f5a4f2b7e" />
After : 
<img width="1016" height="441" alt="Screenshot 2026-01-29 193519" src="https://github.com/user-attachments/assets/23566476-b8a3-407d-ae05-a08876bd8c63" />

- Reference Link

  https://cilium.io/events/