### PR TITLE
Add basic nginx example

### DIFF
--- a/.github/workflow/validate-example.yml
+++ b/.github/workflow/validate-example.yml
@@ -1,0 +1,43 @@
+name: Validate examples
+on:
+  push:
+    paths:
+      - 'examples/**'
+  pull_request:
+    paths:
+      - 'examples/**'
+jobs:
+  kind-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up kind
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: v0.20.0
+
+      - name: Create kind cluster
+        run: |
+          kind create cluster --name examples --wait 60s
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: '1.27.3'
+
+      - name: Apply examples
+        run: |
+          kubectl apply -f examples/basic-nginx/deployment.yaml
+
+      - name: Wait for pods ready
+        run: |
+          kubectl wait --for=condition=ready pod -l app=example-nginx --timeout=120s
+
+      - name: Smoke test service
+        run: |
+          kubectl get svc example-nginx -o yaml

--- a/examples/basic-nginx/deployment.yaml
+++ b/examples/basic-nginx/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-nginx
+  labels:
+    app: example-nginx
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: example-nginx
+  template:
+    metadata:
+      labels:
+        app: example-nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.25
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-nginx
+spec:
+  selector:
+    app: example-nginx
+  ports:
+  - port: 80
+    targetPort: 80
+  type: ClusterIP


### PR DESCRIPTION
This PR adds a simple nginx deployment example and sets up automated testing infrastructure using GitHub Actions.
## What This Does
- Provides a simple starting point for users learning Kubernetes deployments
- Establishes CI/CD infrastructure to automatically validate all examples
- Ensures examples stay functional as the codebase evolves
## Testing
The CI workflow automatically:
- Creates a kind (Kubernetes in Docker) cluster
- Applies the example deployment
- Waits for pods to be ready
- Performs smoke tests on services

issue #888