### PR TITLE
refactor: standardize carousel by removing react-slick

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,10 +57,8 @@
     "react-modal": "^3.16.3",
     "react-paginate": "^8.3.0",
     "react-share": "^4.4.1",
-    "react-slick": "^0.30.3",
     "react-use": "^17.6.0",
     "remark-gfm": "^1.0.0",
-    "slick-carousel": "^1.8.1",
     "swiper": "^11.2.10",
     "tiny-slider": "^2.9.4",
     "yup": "^1.6.1"

--- a/src/components/pages/home/in-production/slider/slider.jsx
+++ b/src/components/pages/home/in-production/slider/slider.jsx
@@ -1,30 +1,30 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, { useEffect } from 'react';
-import SlickSlider from 'react-slick';
-
-import 'slick-carousel/slick/slick-theme.css';
-import 'slick-carousel/slick/slick.css';
+import React, { useRef, useState, useEffect } from 'react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Navigation, Pagination } from 'swiper/modules';
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
 
 import ChevronIcon from './images/chevron.inline.svg';
 
-const Arrow = (props) => {
-  const isNext = props.type === 'next';
-  const isDisabled = props?.className?.includes('slick-disabled');
+const Arrow = ({ type, onClick, disabled }) => {
+  const isNext = type === 'next';
 
   return (
     <button
       className={classNames(
-        'group absolute top-1/2 h-8 w-8 shrink-0 border -translate-y-1/2 items-center transition-colors duration-300 outline-none justify-center overflow-hidden rounded-full',
+        'group absolute top-1/2 h-8 w-8 shrink-0 border -translate-y-1/2 items-center transition-colors duration-300 outline-none justify-center overflow-hidden rounded-full z-10',
         'bg-gray-4 border-gray-1/60 text-gray-2',
         'md:flex hidden',
         isNext ? '-right-9' : '-left-9 scale-x-[-1]',
-        isDisabled ? 'opacity-40' : 'hover:bg-gray-2 hover:border-gray-2 hover:text-gray-4'
+        disabled ? 'opacity-40 cursor-not-allowed' : 'hover:bg-gray-2 hover:border-gray-2 hover:text-gray-4 cursor-pointer'
       )}
       type="button"
       aria-label={`${isNext ? 'Next' : 'Previous'} slide`}
-      disabled={isDisabled}
-      onClick={props.onClick}
+      disabled={disabled}
+      onClick={onClick}
     >
       <ChevronIcon className="w-2.5 shrink-0" />
     </button>
@@ -34,64 +34,101 @@ const Arrow = (props) => {
 Arrow.propTypes = {
   type: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
-  className: PropTypes.string,
+  disabled: PropTypes.bool,
 };
 
 Arrow.defaultProps = {
-  className: '',
+  disabled: false,
 };
 
 const Slider = ({ children, className }) => {
+  const navigationPrevRef = useRef(null);
+  const navigationNextRef = useRef(null);
+  const swiperRef = useRef(null);
+  const [isBeginning, setIsBeginning] = useState(true);
+  const [isEnd, setIsEnd] = useState(false);
+
+  // Convert children to array if needed
+  const childrenArray = React.Children.toArray(children);
+
   useEffect(() => {
-    const showAllSlides = () => {
-      document.querySelectorAll('.slick-slide[aria-hidden]').forEach((slide) => {
-        slide.removeAttribute('aria-hidden');
-      });
-    };
-
-    showAllSlides(); // iinitial run
-
-    const observer = new MutationObserver(showAllSlides);
-    observer.observe(document.body, {
-      attributes: true,
-      subtree: true,
-      attributeFilter: ['aria-hidden'],
-    });
-
-    return () => observer.disconnect();
-  }, []);
-
-  const settings = {
-    dots: false,
-    infinite: false,
-    slidesToShow: 3,
-    slidesToScroll: 1,
-    nextArrow: <Arrow type="next" />,
-    prevArrow: <Arrow type="prev" />,
-    responsive: [
-      {
-        breakpoint: 1024,
-        settings: {
-          slidesToShow: 2,
-        },
-      },
-      {
-        breakpoint: 768,
-        settings: {
-          slidesToShow: 1,
-          dots: true,
-        },
-      },
-    ],
-  };
+    if (swiperRef.current) {
+      setIsBeginning(swiperRef.current.isBeginning);
+      setIsEnd(swiperRef.current.isEnd);
+    }
+  }, [childrenArray.length]);
 
   return (
-    <SlickSlider
-      className={classNames('slick-slider !flex w-full justify-between', className)}
-      {...settings}
-    >
-      {children}
-    </SlickSlider>
+    <div className={classNames('relative w-full', className)}>
+      <Swiper
+        modules={[Navigation, Pagination]}
+        spaceBetween={0}
+        slidesPerView={3}
+        slidesPerGroup={1}
+        navigation={{
+          prevEl: navigationPrevRef.current,
+          nextEl: navigationNextRef.current,
+        }}
+        pagination={{
+          clickable: true,
+          enabled: false, // Disabled by default, enabled on mobile via breakpoints
+        }}
+        breakpoints={{
+          768: {
+            slidesPerView: 1,
+            pagination: {
+              enabled: true,
+            },
+          },
+          1024: {
+            slidesPerView: 2,
+            pagination: {
+              enabled: false,
+            },
+          },
+          1280: {
+            slidesPerView: 3,
+            pagination: {
+              enabled: false,
+            },
+          },
+        }}
+        onBeforeInit={(swiper) => {
+          swiper.params.navigation.prevEl = navigationPrevRef.current;
+          swiper.params.navigation.nextEl = navigationNextRef.current;
+        }}
+        onSwiper={(swiper) => {
+          swiperRef.current = swiper;
+          setIsBeginning(swiper.isBeginning);
+          setIsEnd(swiper.isEnd);
+        }}
+        onSlideChange={(swiper) => {
+          setIsBeginning(swiper.isBeginning);
+          setIsEnd(swiper.isEnd);
+        }}
+        className="swiper-slider w-full"
+      >
+        {childrenArray.map((child, index) => (
+          <SwiperSlide key={index} className="!flex">
+            {child}
+          </SwiperSlide>
+        ))}
+      </Swiper>
+      <div ref={navigationPrevRef}>
+        <Arrow
+          type="prev"
+          onClick={() => swiperRef.current?.slidePrev()}
+          disabled={isBeginning}
+        />
+      </div>
+      <div ref={navigationNextRef}>
+        <Arrow
+          type="next"
+          onClick={() => swiperRef.current?.slideNext()}
+          disabled={isEnd}
+        />
+      </div>
+    </div>
   );
 };
 

--- a/src/styles/slick.css
+++ b/src/styles/slick.css
@@ -1,38 +1,30 @@
 @layer components {
-  .slick-slider {
-    & .slick-slide > div {
-      @apply h-full w-full;
-    }
-
-    & .slick-slide {
-      @apply float-none !flex h-auto;
-    }
-
-    & .slick-track {
-      @apply flex before:hidden after:hidden;
+  .swiper-slider {
+    & .swiper-slide {
+      @apply !flex h-auto;
 
       & > div {
-        @apply py-4 lg:px-4 md:px-2.5 w-full px-4;
+        @apply h-full w-full py-4 lg:px-4 md:px-2.5 px-4;
       }
     }
 
-    & .slick-dots {
+    & .swiper-wrapper {
+      @apply flex;
+    }
+
+    & .swiper-pagination {
       @apply -bottom-7 justify-center !flex;
 
-      & li {
-        @apply mx-0 flex items-center justify-center;
+      & .swiper-pagination-bullet {
+        @apply flex h-5 w-5 items-center justify-center mx-0;
 
-        & button {
-          @apply flex h-5 w-5 items-center justify-center;
-
-          &::before {
-            @apply left-1/2 top-1/2 h-2 w-2 shrink-0 -translate-x-1/2 -translate-y-1/2 rounded-full border border-gray-500/50 text-[0px] opacity-100;
-          }
+        &::before {
+          @apply content-[''] absolute left-1/2 top-1/2 h-2 w-2 shrink-0 -translate-x-1/2 -translate-y-1/2 rounded-full border border-gray-500/50 text-[0px] opacity-100;
         }
+      }
 
-        &.slick-active button::before {
-          @apply border-none bg-primary-1 opacity-100;
-        }
+      & .swiper-pagination-bullet-active::before {
+        @apply border-none bg-primary-1 opacity-100;
       }
     }
   }


### PR DESCRIPTION
### What & Why
The project was using both react-slick and swiper for carousel functionality.
Maintaining two libraries for the same use case increased bundle size and maintenance overhead.

### Changes
- Removed react-slick dependency
- Standardized carousel implementation to use Swiper
- Cleaned up unused CSS and imports

### Notes
This PR focuses on dependency cleanup and refactoring only.
No functional behavior was changed.