### PR TITLE
fix: add missing rel=noopener noreferrer on external links

### DIFF
--- a/src/components/pages/brand/colors/colors.jsx
+++ b/src/components/pages/brand/colors/colors.jsx
@@ -25,6 +25,7 @@ const Colors = ({ title, description, linkUrl = null, colors }) => (
             className="w-full !rounded-md !px-7 sm:w-auto lg:h-[50px] lg:self-end"
             to={linkUrl}
             target="_blank"
+            rel="noopener noreferrer"
             theme="primary-1"
             asDefaultLink
           >

--- a/src/components/pages/brand/hero/hero.jsx
+++ b/src/components/pages/brand/hero/hero.jsx
@@ -23,6 +23,7 @@ const Hero = () => (
         className="mx-auto mt-6 !rounded-md !px-5 sm:mt-7 sm:!px-7"
         to="/data/cilium-brandbook.pdf"
         target="_blank"
+        rel="noopener noreferrer"
         theme="primary-1"
         asDefaultLink
       >

--- a/src/components/pages/labs/banner/banner.jsx
+++ b/src/components/pages/labs/banner/banner.jsx
@@ -12,6 +12,7 @@ const Banner = () => (
       to="https://github.com/cilium/cilium.io/blob/main/CONTRIBUTING.md#listing-labs"
       theme="primary-1"
       target="_blank"
+      rel="noopener noreferrer"
     >
       Submit a PR
     </Button>

--- a/src/components/shared/banner/banner.jsx
+++ b/src/components/shared/banner/banner.jsx
@@ -16,7 +16,7 @@ const Banner = () => (
         theme="outline"
         size="sm"
         to="https://github.com/isovalent/echo"
-        rel="noopner noreferrer"
+        rel="noopener noreferrer"
         target="_blank"
       >
         {buttonText}


### PR DESCRIPTION
## Summary
Adds `rel="noopener noreferrer"` to external links to prevent tabnabbing.

Fixes #899 

## Changes
- Fixed typo: `noopner` → `noopener`
- Added missing `rel` attributes to external links

## References
- [MDN: Links to cross-origin destinations are unsafe](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#security_and_privacy)
- [OWASP: Reverse Tabnabbing](https://owasp.org/www-community/attacks/Reverse_Tabnabbing)

