### PR TITLE
refactor: move HubSpot form ID to environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ ALGOLIA_ADMIN_KEY=
 GATSBY_ALGOLIA_INDEX_NAME=
 
 HUBSPOT_ACCESS_TOKEN=
+GATSBY_HUBSPOT_SUBSCRIBE_FORM_ID=
 
 # Secret keys of Algolia are available in algolia account
 # or netlify environment variables.

--- a/src/components/shared/subscribe-form/subscribe-form.jsx
+++ b/src/components/shared/subscribe-form/subscribe-form.jsx
@@ -11,7 +11,7 @@ import submitHubspotForm from 'utils/submit-hubspot-form';
 import ActiveIcon from './images/active.inline.svg';
 
 const APPEAR_AND_EXIT_ANIMATION_DURATION = 0.5;
-const HUBSPOT_FORM_ID = 'ef11d76b-e770-455f-903b-246d91db193d';
+const HUBSPOT_FORM_ID = process.env.GATSBY_HUBSPOT_SUBSCRIBE_FORM_ID;
 
 const emailRegexp =
   // eslint-disable-next-line no-control-regex, no-useless-escape


### PR DESCRIPTION
Closes #897
## Summary
Moves the hardcoded HubSpot Form ID in [SubscribeForm](cci:1://file:///c:/Users/KIIT0001/oss/cilium.io/src/components/shared/subscribe-form/subscribe-form.jsx:28:0-133:2) to an environment variable.

## Changes
- Updated [subscribe-form.jsx](cci:7://file:///c:/Users/KIIT0001/oss/cilium.io/src/components/shared/subscribe-form/subscribe-form.jsx:0:0-0:0) to read from `process.env.GATSBY_HUBSPOT_SUBSCRIBE_FORM_ID`
- Added the variable to [.env.example](cci:7://file:///c:/Users/KIIT0001/oss/cilium.io/.env.example:0:0-0:0)

## Note for maintainers
After merging, add `GATSBY_HUBSPOT_SUBSCRIBE_FORM_ID=ef11d76b-e770-455f-903b-246d91db193d` to Netlify environment variables.

