### PR TITLE
Fix: Make navbar sticky on scroll

### DIFF
--- a/src/layouts/main/main.jsx
+++ b/src/layouts/main/main.jsx
@@ -116,6 +116,7 @@ const MainLayout = ({ children, headerWithSearch, footerWithTopBorder }) => {
         text="Join us for KubeCon Europe and CiliumCon 2026"
         url="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-events/ciliumcon/"
       />
+      <div className="sticky top-0 z-50 w-full">
       <Header
         navigation={navigation}
         withSearch={headerWithSearch}
@@ -123,6 +124,7 @@ const MainLayout = ({ children, headerWithSearch, footerWithTopBorder }) => {
         handleOverlay={handleOverlay}
         handleCloseClick={handleCloseClick}
       />
+      </div>
       <main className="transition-colors duration-200">{children}</main>
       <Footer withTopBorder={footerWithTopBorder} />
     </div>


### PR DESCRIPTION
### Summary
This PR addresses issue #870 by making the main navigation bar sticky at the top of the viewport. This ensures users can easily access navigation links while scrolling through long content, improving the overall UX on both desktop and mobile.

### Changes
*   **File:** `src/layouts/main/main.jsx`
*   **Change:** Wrapped the `<Header />` component in a sticky container with high z-index (`sticky top-0 z-50 w-full`).

### Verification
*   **Desktop:** Verified that the navbar remains fixed at the top when scrolling down.
*   **Mobile:** Verified that the mobile menu remains accessible and fixed while scrolling.
*   **Z-Index:** Verified that page content scrolls *underneath* the navbar without visual overlapping issues.

Closes #870