### PR TITLE
fix: correct spelling typos in documentation and components

### DIFF
--- a/src/components/pages/brand/legal-box/legal-box.jsx
+++ b/src/components/pages/brand/legal-box/legal-box.jsx
@@ -21,7 +21,7 @@ const LegalBox = () => (
         </a>{' '}
         as may be updated from time to time. You also acknowledge that CNCF is the sole owner of
         CNCF trademarks, promise not to interfere with CNCFs rights in them, and acknowledge that
-        goodwill derived from their use accrues only to CNCF. CNCF may rev'ew use of the branding
+        goodwill derived from their use accrues only to CNCF. CNCF may review use of the branding
         materials at any time and reserves the right to terminate or modify any use.
       </p>
     </Container>

--- a/src/posts/2018-12-03-cni-performance/index.md
+++ b/src/posts/2018-12-03-cni-performance/index.md
@@ -338,7 +338,7 @@ Transfer/sec:      9.01MB
 ```
 
 wrk is able to roughly send 40'0000 requests per second. Let's look at the CPU
-consumption on both the sender and reciever:
+consumption on both the sender and receiver:
 
 ```
 top - 03:03:12 up 1 day,  8:36,  3 users,  load average: 1.16, 0.70, 0.37

--- a/src/posts/2023-05-27-race-conditions/index.md
+++ b/src/posts/2023-05-27-race-conditions/index.md
@@ -2,7 +2,7 @@
 date: '2023-05-27T15:56:00.000Z'
 title: 'Race condition between Kube-proxy and Cilium'
 ogImage: ogimage.jpg
-ogSummary: 'Deep dive into an investigation where a race condition incident occured between Kube-proxy and Cilium'
+ogSummary: 'Deep dive into an investigation where a race condition incident occurred between Kube-proxy and Cilium'
 categories:
   - Community
 externalUrl: 'https://blog.zhouhaibing.com/posts/race-condition-between-kube-proxy-and-cilium/ '


### PR DESCRIPTION
## Summary

This PR fixes three spelling typos across the codebase:
- `occured` → `occurred`
- `reciever` → `receiver`
- `rev'ew` → `review`