### PR TITLE
docs: fix 'dependant' typos to 'dependent' in blog posts

### DIFF
--- a/src/posts/06-12-2017-cilium-100-rc2-grpc-kafka-and-much-more/index.md
+++ b/src/posts/06-12-2017-cilium-100-rc2-grpc-kafka-and-much-more/index.md
@@ -60,7 +60,7 @@ The following is what we consider the missing pieces before declaring 1.0:
 
 - Maturing of the recently merged integration with the [Envoy](https://github.com/envoyproxy/envoy) proxy providing enforcement for HTTP and gRPC going forward as well as the recently added Kafka protocol policy enforcement capability. While Envoy itself is already in heavy use by many users, the integration with Cilium is new.
 
-- Completing the policy enforcement functionality on layer 7\. This includes the ability to integrate with services like Istio Auth for certificate management and the introduction of source dependant layer 7 rules to the Envoy proxy.
+- Completing the policy enforcement functionality on layer 7\. This includes the ability to integrate with services like Istio Auth for certificate management and the introduction of source dependent layer 7 rules to the Envoy proxy.
 
 We looked at several options on what exactly to call this release and how to proceed. Just declaring 1.0 now did not make sense as the layer 7 functionality is at the core of what many users expect of Cilium. We are well past what is considered a beta. We have thus decided to call it a release candidate.
 

--- a/src/posts/16-02-2018-cilium-rc4/index.md
+++ b/src/posts/16-02-2018-cilium-rc4/index.md
@@ -143,7 +143,7 @@ documentation, the highlights are:
 ### Bugfixes Changes
 
 - Avoid concurrent access of rand.Rand (#2823, @tgraf)
-- kafka: Use policy identity cache to lookup identity for L3 dependant rules (#2813, @manalibhutiyani)
+- kafka: Use policy identity cache to lookup identity for L3 dependent rules (#2813, @manalibhutiyani)
 - envoy: Set source identity correctly in access log. (#2807, @jrajahalme)
 - replaced sysctl invocation with echo redirects (#2789, @aanm)
 - Set up the k8s watchers based on the kube-apiserver version 2731 (##2735, @aanm)

--- a/src/posts/2020-10-06-skybet-cilium-migration/index.md
+++ b/src/posts/2020-10-06-skybet-cilium-migration/index.md
@@ -258,7 +258,7 @@ truth for network connectivity.
 
 ## Step 1: Prepare
 
-This step is for installing all our dependant resources, and labelling nodes.
+This step is for installing all our dependent resources, and labelling nodes.
 
 ### Node Labels
 

--- a/src/posts/2021-05-11-cni-benchmark/index.md
+++ b/src/posts/2021-05-11-cni-benchmark/index.md
@@ -84,7 +84,7 @@ conclusions after reading the details first.
 - **Wireguard vs IPsec:** Somewhat surprising, even though Wireguard has been
   able to achieve higher maximum throughputs in our tests, IPsec can be more
   efficient in terms of CPU resources to achieve the same throughput. This is
-  very likely strictly dependant on the availability of AES-NI CPU instructions
+  very likely strictly dependent on the availability of AES-NI CPU instructions
   which allow to offload the crypto work for IPsec whereas Wireguard cannot
   benefit from this. The cards will obviously turn when AES-NI offload is not
   available.


### PR DESCRIPTION
Fixed spelling of `dependant` → `dependent` in 4 blog posts:

- `src/posts/2021-05-11-cni-benchmark/index.md`
- `src/posts/2020-10-06-skybet-cilium-migration/index.md`
- `src/posts/16-02-2018-cilium-rc4/index.md`
- `src/posts/06-12-2017-cilium-100-rc2-grpc-kafka-and-much-more/index.md`
