### PR TITLE
fix: update CiliumCon Europe 2026 event URL

### DIFF
--- a/content/events/2025-11-25-ciliumcon-eu-2026/index.md
+++ b/content/events/2025-11-25-ciliumcon-eu-2026/index.md
@@ -5,6 +5,6 @@ place: Amsterdam, The Netherlands
 title: 'CiliumCon Europe 2026'
 ogSummary: 'CiliumCon is a KubeCon co-located event for Cilium users, contributors, and community members. Join us for CiliumCon Europe 2026 in Amsterdam!'
 ogImage: ogimage.png
-externalUrl: 'https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/ciliumcon/'
+externalUrl: 'https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-events/ciliumcon/'
 isFeatured: true
 ---


### PR DESCRIPTION
Fixes: #909 
- The event was redirecting to KubeCon North America instead of Europe.

- Updated externalUrl to point to the correct Europe 2026 event.