### PR TITLE
fix: add dark mode text colors to subscribe success message

### DIFF
--- a/src/components/shared/subscribe-form/subscribe-form.jsx
+++ b/src/components/shared/subscribe-form/subscribe-form.jsx
@@ -78,7 +78,7 @@ const SubscribeForm = ({ className, inputClassName, buttonClassName, divClassNam
               'remove-autocomplete-styles w-full appearance-none rounded border py-3 pl-6 pr-6 leading-normal shadow-input transition-colors duration-200 xs:rounded-xl xs:py-4 xs:pr-36 md:text-lg lg:py-[22px] lg:text-xl xl:pr-44 bg-white dark:bg-[#dfe5ed]',
               'outline-none hover:border-gray-2 focus:border-primary-1',
               (errors?.email?.message || errorMessage) &&
-                'border-additional-1 hover:border-additional-1 focus:border-additional-1',
+              'border-additional-1 hover:border-additional-1 focus:border-additional-1',
               inputClassName
             )}
             type="email"
@@ -116,11 +116,11 @@ const SubscribeForm = ({ className, inputClassName, buttonClassName, divClassNam
           >
             <div className="flex flex-col items-center justify-center space-y-3 xs:flex-row xs:space-y-0 xs:space-x-2.5">
               <ActiveIcon className="h-9 w-9 shrink-0" />
-              <span className="text-xl font-bold leading-none xs:text-2xl">
+              <span className="text-xl font-bold leading-none xs:text-2xl text-black dark:text-white">
                 Thanks for subscribing!
               </span>
             </div>
-            <span className="mt-3.5 max-w-[280px] text-base leading-normal xs:max-w-none">
+            <span className="mt-3.5 max-w-[280px] text-base leading-normal xs:max-w-none text-black dark:text-gray-2">
               Explore previous releases of eCHO News right now
             </span>
             <Button className="mt-5 lg:text-base" theme="primary-1" size="md" to="#archive">


### PR DESCRIPTION
### Fix
- The success message text was invisible in dark mode.
- Added `dark:text-white` and `dark:text-gray-2` classes.

### Screenshots

**Light mode (working):**  
<img width="889" height="387" alt="Light mode success message visible" src="https://github.com/user-attachments/assets/78527922-c6b7-42f9-a7ba-d7d597bb549d" />

**Dark mode (before fix):**  
<img width="891" height="393" alt="Dark mode success message not visible" src="https://github.com/user-attachments/assets/d6772345-4c3e-461f-948b-15f7704b3ab7" />

**Dark mode (after fix):**  
<img width="902" height="381" alt="image" src="https://github.com/user-attachments/assets/facee050-a689-4c22-ab59-e73bec26dd5d" />
