### PR TITLE
fix: correct DigitalOcean case study URL on tool-consolidation page

### DIFF
--- a/src/pages/outcomes/tool-consolidation.jsx
+++ b/src/pages/outcomes/tool-consolidation.jsx
@@ -99,7 +99,7 @@ const testimonials = [
     CTAs: [
       {
         CTAtext: 'Read The Case Study',
-        url: 'https://www.cncf.io/case-studies/sicredi',
+        url: 'https://www.cncf.io/case-studies/digitalocean/',
       },
     ],
     description:


### PR DESCRIPTION
- The DigitalOcean case study link was wrong and opened the Sicredi page.
- Fixed the link to open the correct DigitalOcean case study.
