### PR TITLE
fix: add dark mode text colors to telling-story success message

### DIFF
--- a/src/components/pages/telling-story/hero/form/form.jsx
+++ b/src/components/pages/telling-story/hero/form/form.jsx
@@ -217,10 +217,10 @@ const Form = ({ formClassName }) => {
               }}
             >
               <img src={successHero} alt="" loading="eager" />
-              <h3 className="text-center text-xl font-semibold leading-none lg:text-3xl">
+              <h3 className="text-center text-xl font-semibold leading-none lg:text-3xl text-black dark:text-white">
                 Thanks for your story!
               </h3>
-              <span className="mt-3 text-center text-sm lg:text-base">
+              <span className="mt-3 text-center text-sm lg:text-base text-gray-1 dark:text-gray-5">
                 We will get in touch with you as soon as possible
               </span>
               <Link className="mt-8 mb-12" type="text" theme="primary" to="/get-involved">


### PR DESCRIPTION
## Fix
- Success message text was invisible in dark mode on the `/telling-story/` page.
- Added `dark:text-white` and `dark:text-gray-5` classes to make the text visible in dark mode.
## Screenshot:
### Before : 
<img width="881" height="465" alt="image" src="https://github.com/user-attachments/assets/50addc37-6a93-40b4-91de-6e50e9e7b01d" />

###  After fix: 
<img width="862" height="457" alt="image" src="https://github.com/user-attachments/assets/9735aaa2-f6b8-4699-81d3-6a4483b33a71" />

 
