### PR TITLE
fix:search modal appears behind navigation header Fixes #917

### DIFF
--- a/src/components/shared/search/search.jsx
+++ b/src/components/shared/search/search.jsx
@@ -91,7 +91,7 @@ const Search = ({ buttonClassName, indices }) => {
             backgroundColor: 'rgba(25, 25, 40, 0.6)',
             backdropFilter: 'blur(0px)',
             WebkitBackdropFilter: 'blur(0px)',
-            zIndex: '30',
+            zIndex: '50',
           },
         }}
         isOpen={isOpen}


### PR DESCRIPTION
Fixes #917

The search modal was appearing behind the header due to z-index stacking issues.

Changes:

Increased modal overlay z-index from 30 to 50 in 
search.jsx