### PR TITLE
fix: industry pages typos, broken links and cleanup case studies data

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -151,6 +151,15 @@ const plugins = [
   'gatsby-plugin-sitemap',
   'gatsby-plugin-image',
   {
+    resolve: 'gatsby-plugin-netlify',
+    options: {
+      headers: {
+        '/fonts/*': ['Cache-Control: public, max-age=31536000, immutable'],
+        '/*': ['Content-Security-Policy: frame-ancestors instruqt.com play.instruqt.com'],
+      },
+    },
+  },
+  {
     resolve: `gatsby-plugin-feed`,
     options: {
       query: `

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -505,11 +505,6 @@ async function getHubspotEmails({ actions: { createNode }, createContentDigest }
             },
           }
         );
-
-        if (!hubspotEmails.ok) {
-          throw new Error(`Hubspot API error: ${hubspotEmails.status} ${hubspotEmails.statusText}`);
-        }
-
         hubspotEmailsData = await hubspotEmails.json();
       } catch (error) {
         console.log(error);
@@ -557,11 +552,6 @@ async function getGithubStars({ actions: { createNode }, createContentDigest, ca
       stars = cacheStarsData.stars;
     } else {
       const response = await fetch(`https://api.github.com/repos/cilium/cilium`);
-
-      if (!response.ok) {
-        throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
-      }
-
       const { stargazers_count } = await response.json();
 
       if (typeof stargazers_count !== 'number') {

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,17 +1,3 @@
 [build]
   publish = "public"
   command = "gatsby build"
-
-[build.environment]
-  GATSBY_CONTINUE_BUILD_ON_MISSING_ADAPTER = "true"
-
-[[headers]]
-  for = "/fonts/*"
-  [headers.values]
-    Cache-Control = "public, max-age=31536000, immutable"
-
-[[headers]]
-  for = "/*"
-  [headers.values]
-    Content-Security-Policy = "frame-ancestors instruqt.com play.instruqt.com"
-

--- a/src/pages/use-cases/ingress.jsx
+++ b/src/pages/use-cases/ingress.jsx
@@ -60,7 +60,7 @@ const sectionContent4 = {
   imageRight: true,
 };
 
-const IngressPage = () => (
+const KubeProxyReplacementPage = () => (
   <MainLayout theme="gray">
     <Hero {...heroContent} />
     <FeatureSection {...sectionContent1} />
@@ -71,7 +71,7 @@ const IngressPage = () => (
   </MainLayout>
 );
 
-export default IngressPage;
+export default KubeProxyReplacementPage;
 
 // eslint-disable-next-line react/prop-types
 export const Head = ({ location: { pathname } }) => {


### PR DESCRIPTION
- Fixed wrong content, broken links, and page layout issues on industry and case study pages.
- Removed duplicate links that went to the same page and fixed small spelling mistakes.

