### PR TITLE
Add blog: Uncovering Pod-to-Pod Traffic in Kubernetes Using Cilium and Hubble

### DIFF
--- a/src/posts/2026-02-18-cilium-hubble-pod-traffic.md
+++ b/src/posts/2026-02-18-cilium-hubble-pod-traffic.md
@@ -1,16 +1,14 @@
 ---
-path: "/blog/2026/02/18/uncovering-pod-to-pod-traffic-cilium-hubble"
-date: "2025-07-27T00:00:00.000Z"
+date: '2025-07-27T00:00:00.000Z'
 title: "Uncovering Pod-to-Pod Traffic in Kubernetes Using Cilium and Hubble"
+ogSummary: 'Learn how to observe and troubleshoot pod-to-pod traffic in Kubernetes using Cilium and Hubble.'
+categories:
+  - How-To
+externalUrl: 'https://medium.com/@0.all_existence.0/uncovering-pod-to-pod-traffic-in-kubernetes-using-cilium-and-hubble-0e59a096cce9'
 tags:
+  - Kubernetes
   - Cilium
   - Hubble
-  - Kubernetes
   - Observability
-categories:
-  - Technology
-externalUrl: "https://medium.com/@0.all_existence.0/uncovering-pod-to-pod-traffic-in-kubernetes-using-cilium-and-hubble-0e59a096cce9"
-ogSummary: "Learn how to observe pod-to-pod traffic in Kubernetes using Cilium and Hubble."
 ---
 
-This post links to an external Medium article.


### PR DESCRIPTION
This PR adds a community blog post linking to a Medium article demonstrating how to observe pod-to-pod traffic in Kubernetes using Cilium and Hubble.

Thanks!
