### PR TITLE
Fix category name in recently-added blog post

### DIFF
--- a/src/posts/02-18-2026-uncovering-pod-to-pod-traffic/index.md
+++ b/src/posts/02-18-2026-uncovering-pod-to-pod-traffic/index.md
@@ -5,7 +5,7 @@ ogSummary: 'Learn how to observe and troubleshoot pod-to-pod traffic in Kubernet
 ogImage: ogimage.png
 categories:
   - How-To
-  - community
+  - Community
 externalUrl: 'https://medium.com/@0.all_existence.0/uncovering-pod-to-pod-traffic-in-kubernetes-using-cilium-and-hubble-0e59a096cce9'
 tags:
   - Kubernetes


### PR DESCRIPTION
Apparently category names are case-sensitive, and adding a name with a different case creates a new category whose URL masks the one from the pre-existing "Community" category. Let's fix the category for the post.
