### PR TITLE
fix: add missing noopener to rel attributes in legal-box

### DIFF
--- a/src/components/pages/brand/legal-box/legal-box.jsx
+++ b/src/components/pages/brand/legal-box/legal-box.jsx
@@ -7,16 +7,16 @@ const LegalBox = () => (
     <Container>
       <p className="with-link-primary text-sm leading-normal tracking-normal text-gray-1">
         By using CNCF brand materials you agree to the
-        <a href="https://www.linuxfoundation.org/terms/" target="_blank" rel="noreferrer">
+        <a href="https://www.linuxfoundation.org/terms/" target="_blank" rel="noopener noreferrer">
           {' '}
           Linux Foundation Terms of Use
         </a>
         , the{' '}
-        <a href="https://www.linuxfoundation.org/trademark-usage/" target="_blank" rel="noreferrer">
+        <a href="https://www.linuxfoundation.org/trademark-usage/" target="_blank" rel="noopener noreferrer">
           Trademark Usage Guidelines
         </a>
         , these CNCF branding guidelines, and all{' '}
-        <a href="https://www.cncf.io/brand-guidelines/#legal" target="_blank" rel="noreferrer">
+        <a href="https://www.cncf.io/brand-guidelines/#legal" target="_blank" rel="noopener noreferrer">
           CNCF rules and policies
         </a>{' '}
         as may be updated from time to time. You also acknowledge that CNCF is the sole owner of


### PR DESCRIPTION
Added missing `noopener` to `rel="noreferrer"` on 3 external links
in [legal-box.jsx](cci:7://file:///c:/Users/KIIT0001/oss/cilium.io/src/components/pages/brand/legal-box/legal-box.jsx:0:0-0:0) for consistency with the rest of the codebase.
