### PR TITLE
fix: improve event card border contrast on events page

### DIFF
--- a/src/components/pages/events/events-board/event-card/event-card.jsx
+++ b/src/components/pages/events/events-board/event-card/event-card.jsx
@@ -48,7 +48,7 @@ const EventCard = ({
   <Link
     to={externalUrl}
     className={classNames(
-      'group flex flex-col rounded-lg border-2 border-gray-6 dark:border-gray-1 transition-all duration-200 hover:border-transparent hover:shadow-tertiary',
+      'group flex flex-col rounded-lg border-2 border-gray-3 dark:border-gray-1 transition-all duration-200 hover:border-transparent hover:shadow-tertiary',
       className
     )}
     target="_blank"


### PR DESCRIPTION
Fixes #933

## Changes

Changed event card border from `border-gray-6` (`#F0F2F4`) to `border-gray-3` (`#E0E5EB`) to improve visual separation against the white page background.

This aligns with the border styling already used in [blog-post-card.jsx](cci:7://file:///c:/Users/KIIT0001/oss/cilium.io/src/components/shared/blog-post-card/blog-post-card.jsx:0:0-0:0) for consistency.

## Before
<img width="1912" height="952" alt="image" src="https://github.com/user-attachments/assets/6822c1be-b341-47f0-8dc2-a2bb570409cd" />
 
## After
<img width="1907" height="918" alt="image" src="https://github.com/user-attachments/assets/94b25b82-a285-4a5d-b107-5caa0ca5fcdb" />
