### PR TITLE
fix: correct typo in README regarding image querying

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ npm run clean
 │   │  ├── pages — React components that are being used specifically on a certain page
 │   │  └── shared — React components that are being used across the whole website
 │   ├── hooks
-│   ├── images — Images that are being quired using graphql. Read more about it here — gatsbyjs.org/docs/working-with-images. Also note, that folder structure should be equal to the structure of components folder
+│   ├── images — Images that are being queried using GraphQL. Read more about it here — gatsbyjs.org/docs/working-with-images. Also note, that folder structure should be equal to the structure of components folder
 │   ├── pages
 │   ├── styles
 │   ├── templates


### PR DESCRIPTION
* Summary

This PR fixes a small typo in the `README.md` file under the Project Structure section
### Changes Made

- Corrected “quired” to “queried”
- Capitalized “graphql” to “GraphQL”

Updated line:

images — Images that are being queried using GraphQL.

* Why This Change

Although minor, fixing documentation typos improves overall readability and professionalism. It also ensures correct terminology (GraphQL) is used consistently across the repository.

* Type of Change

- [x] Documentation update (no code changes)

*Testing

No functional changes were made. This update only modifies README documentation.

Thank you for reviewing!

Fixes #940 