### PR TITLE
fix: add missing rel='noopener noreferrer' to external links

### DIFF
--- a/src/pages/adopters.jsx
+++ b/src/pages/adopters.jsx
@@ -203,7 +203,7 @@ const {
 const hero = {
   title: 'Adopters',
   description:
-    'Here are some of the organizations we know are using Cilium.<br/> If you’re using Cilium and aren’t on this list, <a href="https://github.com/cilium/cilium/blob/master/USERS.md" target="_blank">please submit a pull request</a>!',
+    'Here are some of the organizations we know are using Cilium.<br/> If you’re using Cilium and aren’t on this list, <a href="https://github.com/cilium/cilium/blob/master/USERS.md" target="_blank" rel="noopener noreferrer">please submit a pull request</a>!',
 };
 
 const userCommunity1 = {

--- a/src/pages/industries/security.jsx
+++ b/src/pages/industries/security.jsx
@@ -32,7 +32,7 @@ const heroContent = {
 const tetragonContent = {
   heading: 'Tetragon: eBPF-based Security Observability and Runtime Enforcement',
   description:
-    "<a href='https://tetragon.io' style='text-decoration: underline;' target='_blank'>Tetragon</a> is a flexible Kubernetes-aware security observability and runtime enforcement tool that applies policy and filtering directly with eBPF, allowing for reduced observation overhead, tracking of any process, and real-time enforcement of policies.",
+    "<a href='https://tetragon.io' style='text-decoration: underline;' target='_blank' rel='noopener noreferrer'>Tetragon</a> is a flexible Kubernetes-aware security observability and runtime enforcement tool that applies policy and filtering directly with eBPF, allowing for reduced observation overhead, tracking of any process, and real-time enforcement of policies.",
   imageSrc: 'tetragon',
   imageAlt: 'tetragon image logo',
   contents: [

--- a/src/posts/06-04-2021-war-games-network-policy/index.md
+++ b/src/posts/06-04-2021-war-games-network-policy/index.md
@@ -20,11 +20,11 @@ ogSummary: 'We’ve just launched a new community resource networkpolicy.io, to 
 
 import authors from 'utils/author-data';
 
-We’ve just launched a new community resource: <a href="https://networkpolicy.io" target="_blank">networkpolicy.io</a>, to help people learn how to apply Kubernetes network policies to protect their business-critical workloads. But why do we need network policies at all? Let’s consider why traditional network security approaches aren’t sufficient in the cloud native world, and see what advantages we can gain through network policies.
+We’ve just launched a new community resource: <a href="https://networkpolicy.io" target="_blank" rel="noopener noreferrer">networkpolicy.io</a>, to help people learn how to apply Kubernetes network policies to protect their business-critical workloads. But why do we need network policies at all? Let’s consider why traditional network security approaches aren’t sufficient in the cloud native world, and see what advantages we can gain through network policies.
 
 ![](networkpolicy.png)
 
-Network security isn’t a new concept. The term “firewall”in the context of IT was apparently coined by the scriptwriters of 1983 movie <a href="https://screenrant.com/80s-sci-fi-movies-predicted-the-future/" target="_blank">War Games</a>, and the technology <a href="https://docstore.mik.ua/univercd/cc/td/doc/product/iaabu/centri4/user/scf4ch3.htm#xtocid8" target="_blank">evolved</a> to become commonplace by the early 90s. It should be no surprise that the requirements on network security products have moved on quite a bit after thirty years! Kubernetes has proved to be quite the game-changer for many aspects of deploying and running software, and one of the changes it demands is a new approach to network security.
+Network security isn’t a new concept. The term “firewall”in the context of IT was apparently coined by the scriptwriters of 1983 movie <a href="https://screenrant.com/80s-sci-fi-movies-predicted-the-future/" target="_blank" rel="noopener noreferrer">War Games</a>, and the technology <a href="https://docstore.mik.ua/univercd/cc/td/doc/product/iaabu/centri4/user/scf4ch3.htm#xtocid8" target="_blank" rel="noopener noreferrer">evolved</a> to become commonplace by the early 90s. It should be no surprise that the requirements on network security products have moved on quite a bit after thirty years! Kubernetes has proved to be quite the game-changer for many aspects of deploying and running software, and one of the changes it demands is a new approach to network security.
 
 Fortunately, Kubernetes brings with it the built-in concept[^1] of Network Policy that takes us in the right direction. Even better, Network Policies can be the basis for even stronger, more granular network security than we enjoyed in the old days of monoliths and firewalls.
 
@@ -48,7 +48,7 @@ But in the cloud native world, there is a much looser relationship between host 
 
 ## Network Policy objects
 
-Kubernetes uses Network Policy to define rules about what traffic is allowed within a deployment. Instead of using IP addresses, the pods affected by rules are identified using <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors" target="_blank">Label Selectors</a>, in much the same way that pods are assigned to services. All the pods with the defined label(s) match the policy at any given time, so there’s no need to change the policy to keep up to date with the comings and goings of different pods. And the rules apply wherever a pod lives in the cluster, even if traffic is flowing between pods on the same node.
+Kubernetes uses Network Policy to define rules about what traffic is allowed within a deployment. Instead of using IP addresses, the pods affected by rules are identified using <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors" target="_blank" rel="noopener noreferrer">Label Selectors</a>, in much the same way that pods are assigned to services. All the pods with the defined label(s) match the policy at any given time, so there’s no need to change the policy to keep up to date with the comings and goings of different pods. And the rules apply wherever a pod lives in the cluster, even if traffic is flowing between pods on the same node.
 
 The Kubernetes NetworkPolicy resource also lets us define what external traffic is permitted into (ingress) or out of (egress) a set of pods. In this situation, IP addresses can be useful - for example, other clusters or other sets of machines in your estate can be defined with an IP CIDR (a range of IP addresses).
 
@@ -68,11 +68,11 @@ Fine-grained network policy definitions allow us to give minimal, least-privileg
 
 ## Learning about Network Policies
 
-We’ve just launched <a href="https://networkpolicy.io" target="_blank">networkpolicy.io</a> with lots of useful resources for learning about Network Policies. You’ll find the <a href="https://editor.cilium.io" target="_blank">Network Policy editor</a> is a helpful tool for visualizing the effects that a policy will have on traffic. Network policies can be notoriously tricky and one small mistake can lead to lots of mischief. Using the editor can help avoid these mistakes and give you the confidence to deploy new policies.
+We’ve just launched <a href="https://networkpolicy.io" target="_blank" rel="noopener noreferrer">networkpolicy.io</a> with lots of useful resources for learning about Network Policies. You’ll find the <a href="https://editor.cilium.io" target="_blank" rel="noopener noreferrer">Network Policy editor</a> is a helpful tool for visualizing the effects that a policy will have on traffic. Network policies can be notoriously tricky and one small mistake can lead to lots of mischief. Using the editor can help avoid these mistakes and give you the confidence to deploy new policies.
 
 ![](editor.png)
 
-You might also be interested in the <a href="https://github.com/networkpolicy/tutorial" target="_blank">Network Policy tutorial</a> that walks you through different scenarios for policy rules.
+You might also be interested in the <a href="https://github.com/networkpolicy/tutorial" target="_blank" rel="noopener noreferrer">Network Policy tutorial</a> that walks you through different scenarios for policy rules.
 
 [^1]: Kubernetes defines the NetworkPolicy object but it doesn’t enforce it within Kubernetes. You’ll need a networking plugin - for example Cilium - that does the work. If you use a networking plugin that doesn’t implement network policy, your policies will just be ignored.
 

--- a/src/posts/2021-02-10-network-policy-editor/index.md
+++ b/src/posts/2021-02-10-network-policy-editor/index.md
@@ -24,13 +24,13 @@ import authors from 'utils/author-data';
 
 Implementing Network Policy is a critical part of building a secure Kubernetes-based platform, but the learning curve from simple examples to more complex real-world policies is steep. Not only can it be painful to get the YAML syntax and formatting just right, but more importantly, there are many subtleties in the behavior of the network policy specification (e.g. default allow/deny, namespacing, wildcarding, rules combination, etc.). Even an experienced Kubernetes YAML-wrangler can still easily tie their brain in knots working through an advanced network policy use case.
 
-Over the past years, we have learned a lot about the common challenges while working with many of you in the Cilium community implementing Kubernetes Network Policy. Today, we are excited to announce a new free tool for the community to assist you in your journey with Kubernetes NetworkPolicy: <a href="https://editor.cilium.io" target="_blank">editor.cilium.io</a>:
+Over the past years, we have learned a lot about the common challenges while working with many of you in the Cilium community implementing Kubernetes Network Policy. Today, we are excited to announce a new free tool for the community to assist you in your journey with Kubernetes NetworkPolicy: <a href="https://editor.cilium.io" target="_blank" rel="noopener noreferrer">editor.cilium.io</a>:
 
 <YoutubeIframe embedId='_ebbAeYT2z8?controls=0&autoplay=1&mute=1&loop=1'/>
 
 <div style={{ paddingTop: '30px' }}>
 
-The <a href="https://editor.cilium.io" target="_blank">Kubernetes NetworkPolicy Editor</a> helps you build, visualize, and understand Kubernetes NetworkPolicies.
+The <a href="https://editor.cilium.io" target="_blank" rel="noopener noreferrer">Kubernetes NetworkPolicy Editor</a> helps you build, visualize, and understand Kubernetes NetworkPolicies.
 
 - **Tutorial:** Follow the assisted tutorial to go from not using NetworkPolicies yet to a good security posture.
 - **Interactive Creation:** Create policies in an assisted and interactive way.
@@ -44,7 +44,7 @@ The <a href="https://editor.cilium.io" target="_blank">Kubernetes NetworkPolicy 
 
 <p style={{ marginTop: '40px', fontSize: '120%', fontWeight: 'bold', textAlign: 'center' }}>
   <a href="https://editor.cilium.io" style={{ padding: '8px 12px', color: 'white', textAlign: 'center', background: '#0a53a5', borderRadius: '4px' }}
- target="_blank">Try Network Policy Editor</a>
+ target="_blank" rel="noopener noreferrer">Try Network Policy Editor</a>
 </p>
 
 <a id="how-exactly-does-editor-cilium-io-help"></a>
@@ -87,7 +87,7 @@ As you can see in the editor's visualization, the above network policy will only
 
 How do you do this right?
 
-🤓 <a href="https://editor.cilium.io/?policy-tutorial=allow-cross-namespace" target="_blank">Click here to see how to easily visualize and fix this policy in the editor.</a>
+🤓 <a href="https://editor.cilium.io/?policy-tutorial=allow-cross-namespace" target="_blank" rel="noopener noreferrer">Click here to see how to easily visualize and fix this policy in the editor.</a>
 
 <a name="mistake-2-there-is-a-no-way-its-dns"></a>
 
@@ -129,7 +129,7 @@ Pods will typically reach other Kubernetes services via their DNS name (e.g., se
 
 So how do you solve this?
 
-🤓 <a href="https://editor.cilium.io/?policy-tutorial=allow-kube-dns" target="_blank">Click here to see and fix the mistake in the editor</a>
+🤓 <a href="https://editor.cilium.io/?policy-tutorial=allow-kube-dns" target="_blank" rel="noopener noreferrer">Click here to see and fix the mistake in the editor</a>
 
 ### Mistake 3: Using Traditional Networking Constructs
 
@@ -159,7 +159,7 @@ spec:
 
 However, Pod IPs are ephemeral and unpredictable, and depending on a network plugin implementation, ipBlock rules might only allow egress traffic to destinations outside of the cluster. <a href="https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors" target="_block">Kubernetes documentation</a> recommends using ipBlocks only for IP addresses outside of your cluster. So how do you solve this?
 
-🤓 <a href="https://editor.cilium.io/?policy-tutorial=allow-egress-to-pod" target="_blank">Click to learn how to allow egress to Pod.</a>
+🤓 <a href="https://editor.cilium.io/?policy-tutorial=allow-egress-to-pod" target="_blank" rel="noopener noreferrer">Click to learn how to allow egress to Pod.</a>
 
 ### Mistake 4: Misunderstanding How Policy Rules Combine
 
@@ -193,7 +193,7 @@ Wait... while this is valid YAML and a valid network policy, one extra character
 
 How do you prevent these mistakes?
 
-🤓 <a href="https://editor.cilium.io/?policy-tutorial=combine-policy-rules" target="_blank">Click to inspect the example in the Network Policy Editor</a>
+🤓 <a href="https://editor.cilium.io/?policy-tutorial=combine-policy-rules" target="_blank" rel="noopener noreferrer">Click to inspect the example in the Network Policy Editor</a>
 
 ### Mistake 5: Confusing Different Uses for “{}”
 
@@ -215,7 +215,7 @@ In Network Policy, empty curly braces (i.e., “{}”) can have a different mean
   </div>
 </div>
 
-🤓 <a href="https://editor.cilium.io/?policy-tutorial=empty-selectors" target="_blank">Get the answer with the Network Policy Editor</a>
+🤓 <a href="https://editor.cilium.io/?policy-tutorial=empty-selectors" target="_blank" rel="noopener noreferrer">Get the answer with the Network Policy Editor</a>
 
 ## What's Next?
 
@@ -223,8 +223,8 @@ We hope you found these examples useful, and would love to hear from you if you 
 
 To make sharing network policy examples easy, we have added a simple Share button that leverages Github Gist on the backend, enabling you to convert any example you have created into an easily shared link.
 
-Tweet us at <a href="https://twitter.com/@ciliumproject" target="_blank">@ciliumproject</a> to share your examples, and in the next few weeks we’ll pick a few favorites and send the creators some exclusive Cilium SWAG!
+Tweet us at <a href="https://twitter.com/@ciliumproject" target="_blank" rel="noopener noreferrer">@ciliumproject</a> to share your examples, and in the next few weeks we’ll pick a few favorites and send the creators some exclusive Cilium SWAG!
 
-We’d love to hear your feedback and questions on both the editor and Network Policy in the **#networkpolicy** channel of <a href="https://slack.cilium.io/" target="_blank">Cilium Slack</a>. See you there!
+We’d love to hear your feedback and questions on both the editor and Network Policy in the **#networkpolicy** channel of <a href="https://slack.cilium.io/" target="_blank" rel="noopener noreferrer">Cilium Slack</a>. See you there!
 
 <BlogAuthor {...authors.sergeyGeneralov} />

--- a/src/posts/2021-12-01-service-mesh-beta/index.md
+++ b/src/posts/2021-12-01-service-mesh-beta/index.md
@@ -41,7 +41,7 @@ so that sidecars for each application pod are no longer required. Because eBPF
 allows us to intercept packets at the socket as well as at the network
 interface, Cilium can dramatically shorten the overall path for each packet.
 (Read more about <a target="_blank"
-href="https://thenewstack.io/how-ebpf-streamlines-the-service-mesh/">sidecarless,
+href="https://thenewstack.io/how-ebpf-streamlines-the-service-mesh/" rel="noopener noreferrer">sidecarless,
 eBPF-based Service Mesh</a>.)
 
 ![](sidecarless.png)

--- a/src/utils/author-data.js
+++ b/src/utils/author-data.js
@@ -6,7 +6,7 @@ export default {
   },
   lizRice: {
     header: `<a href="https://twitter.com/lizrice">Liz Rice</a>`,
-    bio: `Liz is Chief Open Source Officer at <a href="https://isovalent.com/?utm_source=website-cilium&utm_medium=referral&utm_campaign=cilium-enterprise" target="_blank">Isovalent</a>, the company behind Cilium. She is also chair of the CNCF's Technical Oversight Committee, and the author of Container Security published by O'Reilly.`,
+    bio: `Liz is Chief Open Source Officer at <a href="https://isovalent.com/?utm_source=website-cilium&utm_medium=referral&utm_campaign=cilium-enterprise" target="_blank" rel="noopener noreferrer">Isovalent</a>, the company behind Cilium. She is also chair of the CNCF's Technical Oversight Committee, and the author of Container Security published by O'Reilly.`,
   },
   luanGuimaraes: {
     header: `Luan Guimarães`,


### PR DESCRIPTION
## Description
This pull request solves a issue #951 minor security and privacy issue across the website by appending `rel="noopener noreferrer"` to all external links utilizing `target="_blank"`. 

When a page links to another page using `target="_blank"`, the new page can gain partial control of the originating page via the `window.opener` object (Reverse Tabnabbing). Adding `noopener` prevents this exploit. Adding `noreferrer` reinforces privacy by stripping the `Referer` HTTP header. 

## Changes Made
- Audited all `.jsx`, `.js`, and `.md` files for `target="_blank"` occurrences.
- Injected `rel="noopener noreferrer"` where it was missing.
- Ensured existing `rel` configurations weren't disrupted.
- Re-ran Prettier globally to ensure changes aligned with formatting standards.

## Testing
- Verified local development build passes.
- Confirmed `eslint` rules pass cleanly.
- Tested affected UI components to ensure external links open securely without disrupting layout.