### PR TITLE
perf: fix Cumulative Layout Shift (CLS) by adding explicit image dimensions

### DIFF
--- a/src/components/pages/events/events-board/card-with-cta/card-with-cta.jsx
+++ b/src/components/pages/events/events-board/card-with-cta/card-with-cta.jsx
@@ -6,7 +6,7 @@ import illustration from './images/illustration.png';
 
 const CardWithCta = () => (
   <div className="flex flex-col items-center rounded-lg bg-additional-5 pb-8 transition-all duration-200 hover:shadow-tertiary md:pb-0">
-    <img className="h-auto w-full" src={illustration} alt="" aria-hidden />
+    <img className="h-auto w-full" src={illustration} alt="" width={768} height={538} aria-hidden />
     <h3 className="px-4 text-center text-22 font-bold leading-snug md:px-10">
       Join eCHO livestream - eBPF & Cilium Office Hours- every Friday!
     </h3>

--- a/src/components/pages/events/events-board/event-card/event-card.jsx
+++ b/src/components/pages/events/events-board/event-card/event-card.jsx
@@ -30,7 +30,14 @@ const EventCover = ({ ogImage, title }) => {
       ref={placeholder}
       style={{ height: placeholderHeight }}
     >
-      <img className="h-full w-full py-2.5" src={placeholderIllustration} alt="" aria-hidden />
+      <img
+        className="h-full w-full py-2.5"
+        src={placeholderIllustration}
+        alt=""
+        width={220}
+        height={162}
+        aria-hidden
+      />
     </div>
   );
 };

--- a/src/components/pages/labs/card/card.jsx
+++ b/src/components/pages/labs/card/card.jsx
@@ -26,7 +26,14 @@ const Cover = ({ ogImage, title }) => {
       ref={placeholder}
       style={{ height: placeholderHeight }}
     >
-      <img className="h-full w-full py-2.5" src={placeholderIllustration} alt="" aria-hidden />
+      <img
+        className="h-full w-full py-2.5"
+        src={placeholderIllustration}
+        alt=""
+        width={220}
+        height={162}
+        aria-hidden
+      />
     </div>
   );
 };

--- a/src/components/pages/newsletter/hero/hero.jsx
+++ b/src/components/pages/newsletter/hero/hero.jsx
@@ -15,7 +15,6 @@ const description =
   'eCHO news is your bi-weekly wrap up of all things eBPF and Cilium. If you want to keep up on the latest in cloud native networking, observability, and security this is your source';
 
 const Hero = () => {
-  
   const { isDarkMode, isReady } = useDarkMode();
 
   return (
@@ -25,6 +24,8 @@ const Hero = () => {
           className="absolute left-1/2 bottom-0 -translate-x-1/2"
           src={isDarkMode ? darkThemeBackgroundSvg : backgroundSvg}
           alt=""
+          width={1600}
+          height={isDarkMode ? 352 : 410}
           aria-hidden
         />
       )}

--- a/src/components/pages/telling-story/hero/form/form.jsx
+++ b/src/components/pages/telling-story/hero/form/form.jsx
@@ -216,7 +216,7 @@ const Form = ({ formClassName }) => {
                 transition: { delay: APPEAR_AND_EXIT_ANIMATION_DURATION },
               }}
             >
-              <img src={successHero} alt="" loading="eager" />
+              <img src={successHero} alt="" width={736} height={224} loading="eager" />
               <h3 className="text-center text-xl font-semibold leading-none lg:text-3xl text-black dark:text-white">
                 Thanks for your story!
               </h3>


### PR DESCRIPTION
This PR improves the site's performance and user experience by resolving Cumulative Layout Shift (CLS) issues  #952 . I have added explicit width and height attributes to <img> tags in several key components.

Adding these attributes allows the browser to calculate the aspect ratio and reserve space for the image before it finishes downloading, preventing the layout from "jumping" or shifting once the image appears.

##Changes Made

Added explicit dimensions to images in the following components:

Labs Card: Added dimensions (220x162) to the placeholder SVG.
Telling Story Form: Added dimensions (736x224) to the success hero SVG.
eCHO Livestream Card: Added dimensions (768x538) to the illustration PNG.
Event Card: Added dimensions (220x162) to the placeholder SVG.
Newsletter Hero: Added dimensions (1600x410 / 1600x352) to the background SVGs.

##Verification

Manual Verification: Verified on local development server (http://localhost:8000).
Inspector Tool: Confirmed that width and height attributes are correctly rendered in the DOM.