### PR TITLE
fix: improve minor phrasing in multi-cluster intro

### DIFF
--- a/src/pages/use-cases/cluster-mesh.jsx
+++ b/src/pages/use-cases/cluster-mesh.jsx
@@ -24,7 +24,7 @@ const heroContent = {
   tagline: 'Unleashing the power of multi-cluster networking with Cilium Cluster Mesh',
   subHeading: 'Seamless connectivity for multiple Kubernetes clusters',
   description:
-    'Multi-cluster Kubernetes setups are often adopted for reasons like fault isolation, scalability, and geographical distribution. This approach can lead to networking complexities. Traditional networking models, in this context, struggle with service discovery, network segmentation, policy enforcement, and load balancing across clusters. Additionally, managing security protocols and policies across multiple environments can be a challenging endeavour due to the distributed nature of services.',
+    'Multi-cluster Kubernetes setups are often adopted for reasons like fault isolation, scalability, and geographical distribution. This approach can lead to networking complexities. With such multi-cluster setups, traditional networking models struggle with service discovery, network segmentation, policy enforcement, and load balancing across clusters. Additionally, managing security protocols and policies across multiple environments can be a challenging endeavour due to the distributed nature of services.',
   imageSrc: AstronautBee,
   imageAlt: 'Astronaut Bee',
   imageWidth: 350,


### PR DESCRIPTION
We recently refactored the clustermesh intro (https://docs.cilium.io/en/latest/network/clustermesh/intro/) in Cilium doc and reused this intro but tweaked it while doing so and this commit is meant to align back the website.

Suggested by Quentin in the doc PR here: https://github.com/cilium/cilium/pull/46021#discussion_r3265369697.

This is a very minor fix so feel free to ignore if you liked the old version better!