### PR TITLE
feat(templates): add BlogPosting JSON-LD structured data to blog post

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -617,6 +617,10 @@ exports.createSchemaCustomization = ({ actions }) => {
     type GithubStars implements Node {
       githubStars: String
     }
+
+    type MdxFrontmatter {
+      author: String
+    }
   `;
   createTypes(typeDefs);
 };

--- a/src/templates/blog-post.jsx
+++ b/src/templates/blog-post.jsx
@@ -33,24 +33,67 @@ const BlogPostPage = (props) => {
   );
 };
 
-export const Head = ({ data: { mdx: postData }, location: { pathname } }) => {
+export const Head = ({ data: { mdx: postData, site }, location: { pathname } }) => {
   const {
-    frontmatter: { title, ogImage, ogSummary },
+    frontmatter: { title, ogImage, ogSummary, dateIso, tags },
   } = postData;
+  const { siteUrl } = site.siteMetadata;
+
+  const description = `${ogSummary.slice(0, 133)}...`;
+  const pageUrl = `${siteUrl}${pathname}`;
+  const imageUrl = ogImage?.childImageSharp?.resize?.src
+    ? `${siteUrl}${ogImage.childImageSharp.resize.src}`
+    : null;
+
   const pageMetadata = {
     title,
-    description: `${ogSummary.slice(0, 133)}...`,
+    description,
     image: ogImage || null,
     slug: pathname,
   };
-  return <SEO data={pageMetadata} />;
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: title,
+    description,
+    url: pageUrl,
+    datePublished: dateIso,
+    dateModified: dateIso,
+    publisher: {
+      '@type': 'Organization',
+      name: 'Cilium',
+      url: siteUrl,
+      logo: {
+        '@type': 'ImageObject',
+        url: `${siteUrl}/images/social-preview.jpg`,
+      },
+    },
+    ...(imageUrl && {
+      image: {
+        '@type': 'ImageObject',
+        url: imageUrl,
+        width: 1200,
+        height: 630,
+      },
+    }),
+    ...(tags?.length > 0 && { keywords: tags.join(', ') }),
+  };
+
+  return <SEO data={pageMetadata} type="article" datePublished={dateIso} jsonLd={jsonLd} />;
 };
 
 export const query = graphql`
   query ($id: String!) {
+    site {
+      siteMetadata {
+        siteUrl
+      }
+    }
     mdx(id: { eq: $id }) {
       frontmatter {
         date(formatString: "MMM DD, yyyy")
+        dateIso: date(formatString: "YYYY-MM-DDTHH:mm:ssZ")
         title
         path
         tags

--- a/src/templates/blog-post.jsx
+++ b/src/templates/blog-post.jsx
@@ -35,7 +35,7 @@ const BlogPostPage = (props) => {
 
 export const Head = ({ data: { mdx: postData, site }, location: { pathname } }) => {
   const {
-    frontmatter: { title, ogImage, ogSummary, dateIso, tags },
+    frontmatter: { title, ogImage, ogSummary, dateIso, tags, author },
   } = postData;
   const { siteUrl } = site.siteMetadata;
 
@@ -60,6 +60,16 @@ export const Head = ({ data: { mdx: postData, site }, location: { pathname } }) 
     url: pageUrl,
     datePublished: dateIso,
     dateModified: dateIso,
+    author: author
+      ? {
+          '@type': 'Person',
+          name: author,
+        }
+      : {
+          '@type': 'Organization',
+          name: 'Cilium',
+          url: siteUrl,
+        },
     publisher: {
       '@type': 'Organization',
       name: 'Cilium',
@@ -97,6 +107,7 @@ export const query = graphql`
         title
         path
         tags
+        author
         ogSummary
         ogImage {
           childImageSharp {


### PR DESCRIPTION
fixes issue #986 
 Added a BlogPosting schema.
 a BlogPosting schema.org JSON-LD blok to the Head export in src/templates/blog-post.jsx
Extended the GraphQL query for fetching siteUrl from siteMetadata and a ISO 8601 date allias alongside the existing human-readable date .passes type="article" and datePublished to the existing SEO componant so Open Graph article tags fires correctly as well