### PR TITLE
fix(seo): add missing twitter:site meta tag

### DIFF
--- a/src/components/shared/seo/seo.jsx
+++ b/src/components/shared/seo/seo.jsx
@@ -17,7 +17,7 @@ const SEO = ({
 } = {}) => {
   const {
     site: {
-      siteMetadata: { siteTitle, siteDescription, siteUrl, siteImage },
+      siteMetadata: { siteTitle, siteDescription, siteUrl, siteImage, authorTwitterAccount },
     },
   } = useStaticQuery(graphql`
     query SEO {
@@ -28,6 +28,7 @@ const SEO = ({
           siteUrl
           siteImage
           siteLanguage
+          authorTwitterAccount
         }
       }
     }
@@ -72,6 +73,7 @@ const SEO = ({
 
       {/* Twitter Card */}
       <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:site" content={authorTwitterAccount} />
       <meta name="twitter:title" content={currentTitle} />
       <meta name="twitter:description" content={currentDescription} />
       <meta name="twitter:image" content={currentImagePath} />


### PR DESCRIPTION
The SEO component was emitting twitter:card, twitter:title, twitter:description, twitter:image, and twitter:creator but was missing the twitter:site tag. This tag identifies the Twitter/X account of the website publisher (@ciliumproject) and is required by Twitter Card validators so that cards rendered on twitter.com are correctly attributed to the project's official account.

The authorTwitterAccount value ('@ciliumproject') is already declared in gatsby-config.js siteMetadata but was never consumed by the SEO component. This change extends the existing GraphQL SEO query to include that field and emits it as a standard <meta name='twitter:site'> tag on every page.

Refs: https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup

Signed-off-by: saiashok103@gmail.com