### PR TITLE
feat(a11y): add skip-to-main-content link for keyboard navigation

### DIFF
--- a/src/layouts/main/main.jsx
+++ b/src/layouts/main/main.jsx
@@ -112,6 +112,13 @@ const MainLayout = ({ children, headerWithSearch, footerWithTopBorder }) => {
 
   return (
     <div className="bg-gray-4 dark:bg-gray-900">
+      {/* Skip to main content — WCAG 2.1 SC 2.4.1 (Bypass Blocks) */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-primary-1 focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-white focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2"
+      >
+        Skip to main content
+      </a>
       <TopBanner
         text="Join us for KubeCon North America and CiliumCon 2026"
         url="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/ciliumcon/"
@@ -125,7 +132,7 @@ const MainLayout = ({ children, headerWithSearch, footerWithTopBorder }) => {
         handleCloseClick={handleCloseClick}
       />
       </div>
-      <main className="transition-colors duration-200">{children}</main>
+      <main id="main-content" className="transition-colors duration-200">{children}</main>
       <Footer withTopBorder={footerWithTopBorder} />
     </div>
   );


### PR DESCRIPTION
Keyboard-only users and screen-reader users currently have no way to bypass the site navigation on every page load. They must Tab through all header links before reaching page content. This violates WCAG 2.1 Success Criterion 2.4.1 (Bypass Blocks), which is a Level A requirement.

This commit adds a visually-hidden anchor element as the very first focusable element in the DOM. The link is invisible in normal browsing but becomes a prominent pill-shaped button when focused via Tab key, allowing users to jump directly to the main content landmark.

Changes:
- Add <a href='#main-content'> as the first child of the root wrapper in src/layouts/main/main.jsx using Tailwind sr-only / focus:not-sr-only pattern so it is hidden until focused
- Add id='main-content' to the <main> element so the anchor target is valid and unambiguous

Tested manually: pressing Tab on any page now immediately surfaces the 'Skip to main content' button before any nav links.

Refs:
- https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html
- https://webaim.org/techniques/skipnav/

Signed-off-by: saiashok103@gmail.com