### PR TITLE
fix: correct broken YouTube URL in Reddit testimonial link

### DIFF
--- a/src/pages/use-cases/runtime-security.jsx
+++ b/src/pages/use-cases/runtime-security.jsx
@@ -52,7 +52,7 @@ const testimonials = [
     CTAs: [
       {
         CTAtext: 'Watch the talk',
-        url: 'https://www.youtube.com/watch?v=YNDp7Id7Bb',
+        url: 'https://www.youtube.com/watch?v=YNDp7Id7Bbs',
       },
     ],
     title: "Don't Get Blown up! Avoiding Configuration Gotchas for Tetragon Newbies",


### PR DESCRIPTION
fixing issue #993 

The "Watch the talk" link for the Reddit testimonial ("Don't Get Blown up! Avoiding Configuration Gotchas for Tetragon Newbies") on
https://cilium.io/use-cases/runtime-security/ points to an invalid video showing "video not available."

this PR fixes the broken link 