### PR TITLE
fix: replace broken Slack invite links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="https://github.com/cilium/cilium">
     <img src="https://img.shields.io/badge/GitHub-cilium/cilium-black?style=for-the-badge&logo=github">
   </a>
-  <a href="https://slack.cilium.io/">
+  <a href="https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack">
     <img src="https://img.shields.io/badge/Slack-Join%20Community-purple?style=for-the-badge&logo=slack">
   </a>
   <a href="https://www.youtube.com/c/eBPFCiliumCommunity/">

--- a/src/components/pages/get-help/event-box/event-box.jsx
+++ b/src/components/pages/get-help/event-box/event-box.jsx
@@ -26,7 +26,7 @@ const links = [
   },
   {
     text: 'Reach out on Slack with questions',
-    url: 'https://slack.cilium.io',
+    url: 'https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack',
     target: '_blank',
   },
 ];

--- a/src/components/pages/newsletter/cards/cards.jsx
+++ b/src/components/pages/newsletter/cards/cards.jsx
@@ -51,7 +51,7 @@ const Cards = () => {
       links: [
         {
           title: 'Send on Slack',
-          url: 'https://slack.cilium.io',
+          url: 'https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack',
           target: '_blank',
         },
         {

--- a/src/components/pages/use-cases/join-us-cards/join-us-cards.jsx
+++ b/src/components/pages/use-cases/join-us-cards/join-us-cards.jsx
@@ -14,7 +14,7 @@ const items = [
     description:
       'Cilium is an open source project that anyone in the community can use, improve, and enjoy. We&apos;d love you to join us on Slack! Find out what&apos;s happening and get involved.',
     buttonText: 'Join the Slack',
-    buttonLink: 'https://slack.cilium.io',
+    buttonLink: 'https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack',
     buttonTarget: '_blank',
   },
   {

--- a/src/components/shared/community/community.jsx
+++ b/src/components/shared/community/community.jsx
@@ -18,7 +18,7 @@ const items = [
     icon: slackIcon,
     title: 'Join our Slack channel',
     titleWidth: 'xl:w-32',
-    url: 'https://slack.cilium.io',
+    url: 'https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack',
     target: '_blank',
   },
   {

--- a/src/components/shared/mobile-menu/mobile-menu.jsx
+++ b/src/components/shared/mobile-menu/mobile-menu.jsx
@@ -92,7 +92,7 @@ const MobileMenu = ({ navigation, isOpen, handleOverlay, handleCloseClick }) => 
           <GithubStars className="bg-white dark:bg-gray-800" />
           <Button
             className="inline-flex items-center leading-none bg-white dark:bg-gray-800"
-            to="https://slack.cilium.io"
+            to="https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack"
             target="_blank"
             rel="noopener noreferrer"
             theme="outline-gray"

--- a/src/html.js
+++ b/src/html.js
@@ -19,7 +19,7 @@ const orgSchema = {
     'https://github.com/cilium',
     'https://twitter.com/ciliumproject',
     'https://www.linkedin.com/company/cilium',
-    'https://slack.cilium.io',
+    'https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack',
     'https://www.youtube.com/channel/UCJFUxkVQTBJh3LD1wYBWvuQ',
   ],
   memberOf: {

--- a/src/pages/get-help.jsx
+++ b/src/pages/get-help.jsx
@@ -20,7 +20,7 @@ const items = [
     description:
       'For live conversation and quick questions, join the Cilium Slack workspace. Don’t forget to say hi!',
     buttonText: 'Join Slack',
-    buttonUrl: 'https://slack.cilium.io',
+    buttonUrl: 'https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack',
     buttonTarget: '_blank',
   },
   {

--- a/src/templates/blog.jsx
+++ b/src/templates/blog.jsx
@@ -16,7 +16,7 @@ const cardItems = [
     description:
       'For live conversation and quick questions, join the Cilium Slack workspace. Don’t forget to say hi!',
     buttonText: 'Join slack workspace',
-    buttonUrl: 'https://slack.cilium.io',
+    buttonUrl: 'https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack',
     buttonTarget: '_blank',
   },
   {


### PR DESCRIPTION
Problem
Slack CTA links on a few current pages are kinda busted rn.
`https://slack.cilium.io/` redirects to `https://isogo.to/cilium_slack`, then 404.

Fix
Swap those links to `https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack`.
That one returns 200, and `/get-involved/` already uses it, so this matches the existing flow.

How to repro
1. Checkout `main`.
2. Open `/get-help/`, `/blog/`, or the mobile menu.
3. Click the Slack CTA.
4. You end up on the 404 redirect hop.

Checks
- `curl -I -L https://slack.cilium.io/`
- `curl -I -L https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack`
- `npm run build`