### PR TITLE
docs: fix spelling and grammar typos in blog posts

### DIFF
--- a/src/posts/2019-12-18-how-to-debug-dns-issuse-in-k8s/index.md
+++ b/src/posts/2019-12-18-how-to-debug-dns-issuse-in-k8s/index.md
@@ -287,7 +287,7 @@ identify and track down DNS issues in your Kubernetes cluster.
 
 To get started:
 
-- Install Cilium using any of the [Installation instrutions](http://docs.cilium.io/en/v1.6/gettingstarted/#installation)
+- Install Cilium using any of the [Installation instructions](http://docs.cilium.io/en/v1.6/gettingstarted/#installation)
 - Deploy Hubble with the metrics dashboard configured: [Setting up Hubble Metrics with Grafana](https://github.com/cilium/hubble/tree/v0.5/tutorials/deploy-hubble-and-grafana)
 - Enable [DNS visiblity](https://github.com/cilium/hubble/blob/v0.5/Documentation/dns_visibility.md)
 - Check out [Cilium Slack] for questions and answers

--- a/src/posts/2020-02-05-how-trip-com-uses-cilium/index.md
+++ b/src/posts/2020-02-05-how-trip-com-uses-cilium/index.md
@@ -185,7 +185,7 @@ to all Cilium users as Kubernetes gains underlying support on the scheduler side
 
 ## Getting started with Cilium
 
-- Install Cilium using any of the [Installation instrutions](http://docs.cilium.io/en/v1.6/gettingstarted/#installation)
+- Install Cilium using any of the [Installation instructions](http://docs.cilium.io/en/v1.6/gettingstarted/#installation)
 - Getting started with AWS ENI: [AWS ENI guide](https://docs.cilium.io/en/v1.6/gettingstarted/aws-eni/)
 - Getting started with BGP: [BGP guide](https://docs.cilium.io/en/v1.6/gettingstarted/kube-router/) (Trip.com replaced kube-router with BIRD)
 

--- a/src/posts/2020-07-27-multitenancy-network-security/index.md
+++ b/src/posts/2020-07-27-multitenancy-network-security/index.md
@@ -79,7 +79,7 @@ Cilium running in kube-proxy replacement mode is protected against the recent `k
 
 Multitenancy brings many advantages but also risks to a Kubernetes environment. Cilium has created a network model where workloads are protected from attacks originating inside or outside of the network perimeter, which therefore moves Kubernetes closer to the future of the Zero-Trust Network. We developed Cilium from the ground up with secure multitenancy built into the design. eBPF gives us the power to realize this in ways that existing implementations simply couldn't.
 
-If you're using (or are looking to use) Cilium for secure multitenancy, head over to our [Slack channel](https://slack.cilium.io) and let us know or ask a question. We have a growing and knowledgable community and we're always interested in helping steer you in the right direction.
+If you're using (or are looking to use) Cilium for secure multitenancy, head over to our [Slack channel](https://slack.cilium.io) and let us know or ask a question. We have a growing and knowledgeable community and we're always interested in helping steer you in the right direction.
 
 ## Image Attribution
 

--- a/src/posts/2025-08-20-cillium-at-kubecon-na-2025/index.md
+++ b/src/posts/2025-08-20-cillium-at-kubecon-na-2025/index.md
@@ -17,7 +17,7 @@ import authors from 'utils/author-data';
 
 ![](kubeconcover.png)
 
-The Cilium community is buzzing to reunite again this November in Atlanta for [KubeCon + CloudNativeCon and CiliumCon North America 2025](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/?utm_source=celium&utm_medium=homepage&utm_campaign=10608228-KubeCon-NA-2025&utm_content=hero). Learn where to find Cilium during the show, which talks to attend, and how to engage with end users, core contributors, and industry leaders.
+The Cilium community is buzzing to reunite again this November in Atlanta for [KubeCon + CloudNativeCon and CiliumCon North America 2025](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/?utm_source=cilium&utm_medium=homepage&utm_campaign=10608228-KubeCon-NA-2025&utm_content=hero). Learn where to find Cilium during the show, which talks to attend, and how to engage with end users, core contributors, and industry leaders.
 
 ## A look back at KubeCon + CloudNativeCon and CiliumCon Europe in London
 

--- a/src/posts/2026-06-07-understanding-kubernetes-network-security/index.md
+++ b/src/posts/2026-06-07-understanding-kubernetes-network-security/index.md
@@ -4,7 +4,7 @@ date: 2026-06-07T09:00:00.000Z
 title: 'Understanding Kubernetes Network Security'
 isFeatured: false
 ogImage: images/cilium-node-agent.png
-ogSummary: 'A comprehensive guide to Understand Kubernetes Network Security. Explore how to move beyond traditional IP firewalls, enforce zero-trust microsegmentation, and secure cloud-native environments using modern eBPF-powered tools like Cilium and robust Network Policies.'
+ogSummary: 'A comprehensive guide to understanding Kubernetes Network Security. Explore how to move beyond traditional IP firewalls, enforce zero-trust microsegmentation, and secure cloud-native environments using modern eBPF-powered tools like Cilium and robust Network Policies.'
 
 categories:
   - Security


### PR DESCRIPTION
## Summary
- Fix `utm_source=celium` → `cilium` in KubeCon NA 2025 registration link
- Fix grammar in network security pillar post ogSummary
- Fix `knowledgable` → `knowledgeable` in multitenancy post
- Fix `instrutions` → `instructions` in two older posts

## Test plan
- [ ] Review changed lines in the 5 blog post files