### PR TITLE
fix: revert slack url

### DIFF
--- a/src/components/pages/get-help/event-box/event-box.jsx
+++ b/src/components/pages/get-help/event-box/event-box.jsx
@@ -26,7 +26,7 @@ const links = [
   },
   {
     text: 'Reach out on Slack with questions',
-    url: 'https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack',
+    url: 'https://slack.cilium.io/',
     target: '_blank',
   },
 ];

--- a/src/components/pages/newsletter/cards/cards.jsx
+++ b/src/components/pages/newsletter/cards/cards.jsx
@@ -51,7 +51,7 @@ const Cards = () => {
       links: [
         {
           title: 'Send on Slack',
-          url: 'https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack',
+          url: 'https://slack.cilium.io/',
           target: '_blank',
         },
         {

--- a/src/components/pages/use-cases/join-us-cards/join-us-cards.jsx
+++ b/src/components/pages/use-cases/join-us-cards/join-us-cards.jsx
@@ -14,7 +14,7 @@ const items = [
     description:
       'Cilium is an open source project that anyone in the community can use, improve, and enjoy. We&apos;d love you to join us on Slack! Find out what&apos;s happening and get involved.',
     buttonText: 'Join the Slack',
-    buttonLink: 'https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack',
+    buttonLink: 'https://slack.cilium.io/',
     buttonTarget: '_blank',
   },
   {

--- a/src/components/shared/community/community.jsx
+++ b/src/components/shared/community/community.jsx
@@ -18,7 +18,7 @@ const items = [
     icon: slackIcon,
     title: 'Join our Slack channel',
     titleWidth: 'xl:w-32',
-    url: 'https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack',
+    url: 'https://slack.cilium.io/',
     target: '_blank',
   },
   {

--- a/src/components/shared/header/header.jsx
+++ b/src/components/shared/header/header.jsx
@@ -61,7 +61,7 @@ const Header = ({ withSearch, isMobileMenuOpen, handleCloseClick, navigation, ha
                       'ml-4 items-center bg-white dark:bg-gray-800 leading-none lg:ml-0 xl:ml-2 2xl:ml-4',
                       withSearch ? 'hidden xl:inline-flex' : 'inline-flex'
                     )}
-                    to="https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack"
+                    to="https://slack.cilium.io/"
                     target="_blank"
                     rel="noopener noreferrer"
                     theme="outline-gray"

--- a/src/components/shared/mobile-menu/mobile-menu.jsx
+++ b/src/components/shared/mobile-menu/mobile-menu.jsx
@@ -92,7 +92,7 @@ const MobileMenu = ({ navigation, isOpen, handleOverlay, handleCloseClick }) => 
           <GithubStars className="bg-white dark:bg-gray-800" />
           <Button
             className="inline-flex items-center leading-none bg-white dark:bg-gray-800"
-            to="https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack"
+            to="https://slack.cilium.io/"
             target="_blank"
             rel="noopener noreferrer"
             theme="outline-gray"

--- a/src/pages/get-help.jsx
+++ b/src/pages/get-help.jsx
@@ -20,7 +20,7 @@ const items = [
     description:
       'For live conversation and quick questions, join the Cilium Slack workspace. Don’t forget to say hi!',
     buttonText: 'Join Slack',
-    buttonUrl: 'https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack',
+    buttonUrl: 'https://slack.cilium.io/',
     buttonTarget: '_blank',
   },
   {

--- a/src/pages/get-involved.jsx
+++ b/src/pages/get-involved.jsx
@@ -21,7 +21,7 @@ const cardItems1 = [
     title: 'Slack',
     description: 'For live conversation and quick questions, join the Cilium Slack workspace.',
     buttonText: 'Join slack workspace',
-    buttonUrl: 'https://communityinviter.com/apps/cilium/cilium-and-ebpf-slack',
+    buttonUrl: 'https://slack.cilium.io/',
     buttonTarget: '_blank',
   },
   {


### PR DESCRIPTION
Community inviter has sunsetted the previous platform. I am reverting back to the previous slack url pending when we figure out next steps 